### PR TITLE
Fix systemd user unit management so that users can place own unit files in /etc/local/systemd (#20984)

### DIFF
--- a/nixos/modules/flyingcircus/lib/files.nix
+++ b/nixos/modules/flyingcircus/lib/files.nix
@@ -1,13 +1,19 @@
 { lib, fclib, ... }: with lib;
 
-{
+rec {
 
+
+  # Get all regular files with their name relative to path
+  filesRel = path:
+    (attrNames
+      (filterAttrs
+        (filename: type: (type == "regular"))
+        (builtins.readDir path)));
+
+  # Get all regular files with their absolute name
   files = path:
     (map
       (filename: path + "/" + filename)
-      (attrNames
-        (filterAttrs
-          (filename: type: (type == "regular"))
-          (builtins.readDir path))));
+      (filesRel path));
 
 }

--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -41,6 +41,7 @@ in
     ./ssl/certificate.nix
     ./ssl/dhparams.nix
     ./user.nix
+    ./systemd.nix
   ];
 
   options = {
@@ -298,5 +299,6 @@ in
       then cfg.enc.parameters.timezone
       else "UTC";
   };
+
 
 }

--- a/nixos/modules/flyingcircus/platform/logrotate/default.nix
+++ b/nixos/modules/flyingcircus/platform/logrotate/default.nix
@@ -78,14 +78,15 @@ in
         { "${user.name}-logrotate" = {
           description   = "Logrotate Service for ${user.name}";
           wantedBy      = [ "multi-user.target" ];
-          startAt       = "*-*-* 02:05:00";
+          startAt       = "*-*-* 00:05:00";
 
           path = [ pkgs.bash pkgs.logrotate ];
 
           serviceConfig.User = "${user.name}";
           serviceConfig.Restart = "no";
           serviceConfig.ExecStart = "${./user-logrotate.sh} ${localConfig}";
-          };}) service_users;
+          };
+        }) service_users;
       units_merged = zipAttrsWith (name: values: (last values)) units;
       in
         mkIf (localConfig != null) units_merged;

--- a/nixos/modules/flyingcircus/platform/systemd.nix
+++ b/nixos/modules/flyingcircus/platform/systemd.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+
+  fclib = import ../lib;
+
+in {
+
+  config = {
+
+    system.activationScripts.haproxy = ''
+      install -d -o root -g service -m 02775 /etc/local/systemd
+    '';
+
+    systemd.units =
+      let
+        unit_files = if (builtins.pathExists "/etc/local/systemd")
+          then fclib.filesRel "/etc/local/systemd" else [];
+        unit_configs = map
+          (file: { "${file}" =
+             { text = readFile ("/etc/local/systemd/" + file);
+               wantedBy = [ "multi-user.target" ];};})
+          unit_files;
+        unit_configs_merged = zipAttrsWith (name: values: (last values)) unit_configs;
+      in
+        unit_configs_merged;
+
+  };
+
+}

--- a/nixos/modules/flyingcircus/platform/systemd.nix
+++ b/nixos/modules/flyingcircus/platform/systemd.nix
@@ -9,7 +9,7 @@ in {
 
   config = {
 
-    system.activationScripts.haproxy = ''
+    system.activationScripts.systemd_local = ''
       install -d -o root -g service -m 02775 /etc/local/systemd
     '';
 

--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -105,9 +105,9 @@ let
       userdata;
 
   configure_lingering = userdata:
-    # Service users should have lingering enabled
+    # No users should have lingering enabled
     map
-      (user: " ${config.systemd.package}/bin/loginctl ${if (get_primary_group user) == "service" then "enable" else "disable"}-linger ${user.uid}")
+      (user: " ${config.systemd.package}/bin/loginctl disable-linger ${user.uid}")
       userdata;
 
 in
@@ -223,11 +223,11 @@ in
       %service  ALL=(root) FCMANAGE
     '';
 
-    system.activationScripts.fcio-homedirpermissions =
-      builtins.concatStringsSep "\n" (home_dir_permissions userdata);
+    system.activationScripts.fcio-homedirpermissions = lib.stringAfter [ "users" ]
+      (builtins.concatStringsSep "\n" (home_dir_permissions userdata));
 
-    system.activationScripts.fcio-configure-lingering =
-      builtins.concatStringsSep "\n" (configure_lingering userdata);
+    system.activationScripts.fcio-configure-lingering = lib.stringAfter [ "users" ]
+      (builtins.concatStringsSep "\n" (configure_lingering userdata));
 
   };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

a) provide /etc/local/systemd where service users can place
   arbitrary unit files that will be merged with ``fc-manage``

b) revamp the logrotate integration. every user gets his own
   timer that explicitly changes to the user in the service config
   instead of being injected into the systemd user instance.

c) no lingering, no loitering, no littering.