### PR TITLE
simplify local.nix for new nodes

### DIFF
--- a/nixos/modules/flyingcircus/files/etc_nixos_local.nix
+++ b/nixos/modules/flyingcircus/files/etc_nixos_local.nix
@@ -1,17 +1,9 @@
 # Add manual, temporary configuration here.
-{ ... }:
+{ pkgs, ... }:
 {
 
-#    flyingcircus.agent.enable = false;
-
-#    # Load ENC from file?
-#    fcio.load_enc = false;
-#
-#    # Set additional ENC values here.
-#    fcio.enc = {
-#      parameters = {
-#        directory_secret = "foo!";
-#      };
-#    };
+# flyingcircus.agent.enable = false;
+# environment.systemPackages = [
+# ];
 
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

The whole ENC thingy is not so relevant on the platform. Thus remove it. temporariliy adding packages is a more common.