### PR TITLE
provide swapfiles for vagant

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -104,8 +104,7 @@ with lib;
             script =
               ''
                 if [ ! -e "${sw.device}" ]; then
-                  fallocate -l ${toString sw.size}M "${sw.device}" ||
-                    dd if=/dev/zero of="${sw.device}" bs=1M count=${toString sw.size}
+                   dd if=/dev/zero of="${sw.device}" bs=1M count=${toString sw.size}
                   chmod 0600 ${sw.device}
                   mkswap ${sw.device}
                 fi

--- a/nixos/modules/flyingcircus/vagrant-provision.nix
+++ b/nixos/modules/flyingcircus/vagrant-provision.nix
@@ -11,6 +11,11 @@ with config;
 
   flyingcircus.network.policy_routing.enable = false;
 
+  swapDevices = [
+    { device = "/var/swapfile";
+      size = 2048; }
+  ];
+
   flyingcircus.enc = {
     parameters = {
       location = "vagrant";


### PR DESCRIPTION
@flyingcircusio/release-managers

fallocate creates a sparse file which is not suiteable for swap (at least with the XFS version which is running). Thus never use it, but use dd.

re #21522