### PR TITLE
Allow generic systemctl calls for service users (not only systemctl fc-manage) (#22013)

### DIFF
--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -218,9 +218,9 @@ in
       %sudo-srv ALL=(root) REBOOT
 
       # Allow applying config and restarting services to service users
-      Cmnd_Alias  FCMANAGE = ${pkgs.systemd}/bin/systemctl start fc-manage
-      %sudo-srv ALL=(root) FCMANAGE
-      %service  ALL=(root) FCMANAGE
+      Cmnd_Alias  SYSTEMCTL = ${pkgs.systemd}/bin/systemctl
+      %sudo-srv ALL=(root) SYSTEMCTL
+      %service  ALL=(root) SYSTEMCTL
     '';
 
     system.activationScripts.fcio-homedirpermissions = lib.stringAfter [ "users" ]


### PR DESCRIPTION
@flyingcircusio/release-managers

This is the way I understand https://flyingcircus.io/doc/guide/platform_nixos/base.html#interaction

This is a rather broad rule. But since users can just put in systemd units and run them as root it's not much of a difference, is it.

re #22013