### PR TITLE
Allow FE access to/from same RG machines

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcmanage/src/fcmanage/manage.py
+++ b/nixos/modules/flyingcircus/packages/fcmanage/src/fcmanage/manage.py
@@ -132,6 +132,8 @@ def update_inventory():
         (lambda: directory.lookup_node(enc['name']), 'enc.json'),
         (lambda: directory.list_nodes_addresses(
             enc['parameters']['location'], 'srv'), 'addresses_srv.json'),
+        (lambda: directory.list_nodes_addresses(
+            enc['parameters']['location'], 'fe'), 'addresses_fe.json'),
         (lambda: directory.list_permissions(), 'permissions.json'),
         (lambda: directory.list_service_clients(), 'service_clients.json'),
         (lambda: directory.list_services(), 'services.json'),

--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -23,6 +23,7 @@ let
     (get_json /etc/nixos/enc.json {});
 
   enc_addresses.srv = get_json cfg.enc_addresses_path.srv [];
+  enc_addresses.fe = get_json cfg.enc_addresses_path.fe [];
 
   enc_services = get_json cfg.enc_services_path [];
 
@@ -81,6 +82,27 @@ in
 
     flyingcircus.enc_addresses_path.srv = mkOption {
       default = /etc/nixos/addresses_srv.json;
+      type = types.path;
+      description = "Where to find the address list json file.";
+    };
+
+    flyingcircus.enc_addresses.fe = mkOption {
+      default = enc_addresses.fe;
+      type = types.listOf types.attrs;
+      description = "List of addresses of machines in the neighbourhood.";
+      example = [ {
+        ip = "2a02:238:f030:1c3::104c/64";
+        mac = "02:00:00:03:11:b1";
+        name = "test03";
+        rg = "test";
+        rg_parent = "";
+        ring = 1;
+        vlan = "fe";
+      } ];
+    };
+
+    flyingcircus.enc_addresses_path.fe = mkOption {
+      default = /etc/nixos/addresses_fe.json;
       type = types.path;
       description = "Where to find the address list json file.";
     };

--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -232,15 +232,32 @@ in
     networking.firewall.rejectPackets = true;
     networking.firewall.extraCommands =
       let
-        addrs = map (elem: elem.ip) cfg.enc_addresses.srv;
-        rules = lib.optionalString
-          (lib.hasAttr "ethsrv" networking.interfaces)
-          (lib.concatMapStrings (a: ''
-            ${iptables a} -A nixos-fw -i ethsrv -s ${fclib.stripNetmask a
-              } -j nixos-fw-accept
-            '')
+        addrs_srv = map (elem: elem.ip) cfg.enc_addresses.srv;
+        addrs_fe = map (elem: elem.ip) cfg.enc_addresses.fe;
+        rule = eth: a: ''
+          ${iptables a} -A nixos-fw -i ${eth} -s ${fclib.stripNetmask a
+            } -j nixos-fw-accept
+        '';
+        rules_for = eth: addrs:
+          (lib.concatMapStrings
+            (rule eth)
             addrs);
-      in "# Accept traffic within the same resource group.\n${rules}";
+        rules_srv = lib.optionalString
+          (lib.hasAttr "ethsrv" networking.interfaces)
+          (rules_for "ethsrv" addrs_srv);
+        rules_fe = lib.optionalString
+          (lib.hasAttr "ethfe" networking.interfaces)
+          (rules_for "ethfe" addrs_fe);
+        rules_srv_to_fe = lib.optionalString
+          (lib.hasAttr "ethsrv" networking.interfaces)
+          (rules_for "ethsrv" addrs_fe);
+      in ''
+        # Accept traffic within the same resource group.
+        ${rules_srv}
+        ${rules_fe}
+        # Accept traffic from other SRV to our FE
+        ${rules_srv_to_fe}
+      '';
 
     # DHCP settings: never use implicitly, never do IPv4ll
     networking.useDHCP = false;

--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -249,8 +249,8 @@ in
           (lib.hasAttr "ethfe" networking.interfaces)
           (rules_for "ethfe" addrs_fe);
         rules_srv_to_fe = lib.optionalString
-          (lib.hasAttr "ethsrv" networking.interfaces)
-          (rules_for "ethsrv" addrs_fe);
+          (lib.hasAttr "ethfe" networking.interfaces)
+          (rules_for "ethfe" addrs_srv);
       in ''
         # Accept traffic within the same resource group.
         ${rules_srv}


### PR DESCRIPTION
Change: For a VPN-enabled resource group allow access to ethfe to/from other members of the RG (#22135)

@flyingcircusio/release-managers

re #22135