### PR TITLE
Add sensuclient user to services group.

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -171,6 +171,9 @@ in {
       description = "sensu client daemon user";
       uid = config.ids.uids.sensuclient;
       group = "sensuclient";
+      # Allow sensuclient to interact with services. This especially helps to
+      # check supervisor with a group-writable socket:
+      extraGroups = ["service"];
     };
 
     systemd.services.sensu-client = {
@@ -178,7 +181,7 @@ in {
       path = [ pkgs.sensu pkgs.glibc pkgs.nagiosPluginsOfficial pkgs.bash pkgs.lm_sensors ];
       serviceConfig = {
         User = "sensuclient";
-        ExecStart = "${sensu}/bin/sensu-client -L warn  -c ${client_json} ${local_sensu_configuration}";
+        ExecStart = "${sensu}/bin/sensu-client -L warn -c ${client_json} ${local_sensu_configuration}";
         Restart = "always";
         RestartSec = "5s";
       };


### PR DESCRIPTION
@flyingcircusio/release-managers

This allows sensuclient to interact with services more easily. This especially helps to check supervisor with a group-writable socket.

Also change some arbitrary white-space to trigger a restart of sensuclient.