### PR TITLE
Make systemd journal world-readable (#22577)

### DIFF
--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -266,19 +266,6 @@ in
         });
       };
 
-    system.activationScripts.journal = ''
-      # Ensure journal access for privileged users.
-      # This fails if the users are not there (hence || true). This does not
-      # matter though: a non existing user/group does not need access.
-      # Command line taken from systemd-journald.service(8)
-      ${pkgs.acl}/bin/setfacl -Rn \
-        -m g:sudo-srv:rx,d:g:sudo-srv:rx \
-        -m g:admins:rx,d:g:admins:rx \
-        -m g:wheel:rx,d:g:wheel:rx \
-        -m g:sensuclient:rx,d:g:sensuclient:rx \
-        /var/log/journal/ || true
-    '';
-
     environment.etc = (
       lib.optionalAttrs (lib.hasAttrByPath ["parameters" "directory_secret"] cfg.enc)
       { "directory.secret".text = cfg.enc.parameters.directory_secret;
@@ -292,12 +279,10 @@ in
     };
     services.nscd.enable = true;
 
-    services.journald.extraConfig = "SystemMaxUse=1G";
     systemd.tmpfiles.rules = [
       # d instead of r to a) respect the age rule and b) allow exclusion
       # of fc-data to avoid killing the seeded ENC upon boot.
       "d /tmp 1777 root root 3d"
-      "x /tmp/fc-data/*"
       "d /var/tmp 1777 root root 7d"
       "d /srv"
       "z /srv 0755 root root"
@@ -308,6 +293,5 @@ in
       then cfg.enc.parameters.timezone
       else "UTC";
   };
-
 
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

I think there is not much of a point to hide journal messages from some
users. Make them readable by anyone.

Also restructured platform/default.nix vs. platform/systemd.nix a bit so
I hope it will be easier to find certain stuff in the future.

Fixes #22577