### PR TITLE
Update Postfix to 3.0.3 and extend mailserver role for custom local.cf and canonical.pcre 

### DIFF
--- a/nixos/modules/flyingcircus/packages/default.nix
+++ b/nixos/modules/flyingcircus/packages/default.nix
@@ -19,7 +19,12 @@
     fcsensuplugins = pkgs.callPackage ./fcsensuplugins { };
     fcutil = pkgs.callPackage ./fcutil { };
 
+    mc = pkgs.callPackage ./mc.nix { };
+    mongodb32 = pkgs.callPackage ./mongodb { sasl = pkgs.cyrus_sasl; };
+
     nagiosplugin = pkgs.callPackage ./nagiosplugin.nix { };
+
+    osm2pgsql = pkgs.callPackage ./osm2pgsql.nix { };
 
     postfix = pkgs.callPackage ./postfix/3.0.nix { };
     powerdns = pkgs.callPackage ./powerdns.nix { };
@@ -32,16 +37,6 @@
 
     sensu = pkgs.callPackage ./sensu { };
     uchiwa = pkgs.callPackage ./uchiwa { };
-
-    mc = pkgs.callPackage ./mc.nix { };
-
-    osm2pgsql = pkgs.callPackage ./osm2pgsql.nix { };
-
-    mongodb32 = pkgs.callPackage ./mongodb {
-      # I overwrite this here and not in mongodb/default.nix as it is copied
-      # without any change.
-      sasl = pkgs.cyrus_sasl;
-    };
 
   };
 }

--- a/nixos/modules/flyingcircus/packages/default.nix
+++ b/nixos/modules/flyingcircus/packages/default.nix
@@ -21,6 +21,7 @@
 
     nagiosplugin = pkgs.callPackage ./nagiosplugin.nix { };
 
+    postfix = pkgs.callPackage ./postfix/3.0.nix { };
     powerdns = pkgs.callPackage ./powerdns.nix { };
     pypkgs = pkgs.callPackage ./pypkgs.nix { };
 

--- a/nixos/modules/flyingcircus/packages/postfix/3.0.nix
+++ b/nixos/modules/flyingcircus/packages/postfix/3.0.nix
@@ -1,0 +1,91 @@
+{ stdenv, lib, fetchurl, makeWrapper, gnused, db, openssl, cyrus_sasl
+, coreutils, findutils, gnugrep, gawk, icu, pcre
+, withPgSQL ? false, postgresql
+, withMySQL ? false, libmysql
+, withSQLite ? false, sqlite
+}:
+
+let
+  ccargs = lib.concatStringsSep " " ([
+    "-DUSE_TLS" "-DUSE_SASL_AUTH" "-DUSE_CYRUS_SASL" "-I${cyrus_sasl}/include/sasl"
+    "-DHAS_DB_BYPASS_MAKEDEFS_CHECK"
+    "-fPIE" "-fstack-protector-all" "--param" "ssp-buffer-size=4" "-O2" "-D_FORTIFY_SOURCE=2"
+   ] ++ lib.optional withPgSQL "-DHAS_PGSQL"
+     ++ lib.optionals withMySQL [ "-DHAS_MYSQL" "-I${libmysql}/include/mysql" ]
+     ++ lib.optional withSQLite "-DHAS_SQLITE");
+   auxlibs = lib.concatStringsSep " " ([
+     "-ldb" "-lnsl" "-lresolv" "-lsasl2" "-lcrypto" "-lssl" "-pie" "-Wl,-z,relro,-z,now"
+   ] ++ lib.optional withPgSQL "-lpq"
+     ++ lib.optional withMySQL "-lmysqlclient"
+     ++ lib.optional withSQLite "-lsqlite3");
+
+in stdenv.mkDerivation rec {
+
+  name = "postfix-${version}";
+
+  version = "3.0.3";
+
+  src = fetchurl {
+    url = "ftp://ftp.cs.uu.nl/mirror/postfix/postfix-release/official/${name}.tar.gz";
+    sha256 = "00mc12k5p1zlrlqcf33vh5zizaqr5ai8q78dwv69smjh6kn4c7j0";
+  };
+
+  buildInputs = [ makeWrapper gnused db openssl cyrus_sasl icu pcre ]
+                ++ lib.optional withPgSQL postgresql
+                ++ lib.optional withMySQL libmysql
+                ++ lib.optional withSQLite sqlite;
+
+  patches = [
+    ./postfix-script-shell.patch
+    ./postfix-3.0-no-warnings.patch
+    ./post-install-script.patch
+    ./relative-symlinks.patch
+  ];
+
+  preBuild = ''
+    sed -e '/^PATH=/d' -i postfix-install
+    sed -e "s|@PACKAGE@|$out|" -i conf/post-install
+
+    # post-install need skip permissions check/set on all symlinks following to /nix/store
+    sed -e "s|@NIX_STORE@|$NIX_STORE|" -i conf/post-install
+
+    export command_directory=$out/sbin
+    export config_directory=/etc/postfix
+    export meta_directory=$out/etc/postfix
+    export daemon_directory=$out/libexec/postfix
+    export data_directory=/var/lib/postfix/data
+    export html_directory=$out/share/postfix/doc/html
+    export mailq_path=$out/bin/mailq
+    export manpage_directory=$out/share/man
+    export newaliases_path=$out/bin/newaliases
+    export queue_directory=/var/lib/postfix/queue
+    export readme_directory=$out/share/postfix/doc
+    export sendmail_path=$out/bin/sendmail
+
+    make makefiles CCARGS='${ccargs}' AUXLIBS='${auxlibs}'
+  '';
+
+  installTargets = [ "non-interactive-package" ];
+
+  installFlags = [ "install_root=installdir" ];
+
+  postInstall = ''
+    mkdir -p $out
+    mv -v installdir/$out/* $out/
+    cp -rv installdir/etc $out
+    sed -e '/^PATH=/d' -i $out/libexec/postfix/post-install
+    wrapProgram $out/libexec/postfix/post-install \
+      --prefix PATH ":" ${coreutils}/bin:${findutils}/bin:${gnugrep}/bin
+    wrapProgram $out/libexec/postfix/postfix-script \
+      --prefix PATH ":" ${coreutils}/bin:${findutils}/bin:${gnugrep}/bin:${gawk}/bin:${gnused}/bin
+  '';
+
+  meta = {
+    homepage = "http://www.postfix.org/";
+    description = "A fast, easy to administer, and secure mail server";
+    license = lib.licenses.bsdOriginal;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.rickynils ];
+  };
+
+}

--- a/nixos/modules/flyingcircus/packages/postfix/post-install-script.patch
+++ b/nixos/modules/flyingcircus/packages/postfix/post-install-script.patch
@@ -1,0 +1,28 @@
+--- a/conf/post-install	1970-01-01 03:00:01.000000000 +0300
++++ b/conf/post-install	2016-01-20 13:25:18.382233172 +0200
+@@ -254,6 +254,8 @@
+ }
+ 
+ # Bootstrapping problem.
++meta_directory="@PACKAGE@/etc/postfix"
++command_directory="@PACKAGE@/bin"
+ 
+ if [ -n "$command_directory" ]
+ then
+@@ -528,7 +530,16 @@
+ 	    # Skip uninstalled files.
+ 	    case $path in
+ 	    no|no/*) continue;;
++        # Skip immutable files from package, correct permissions provided by Nix.
++        @PACKAGE@/*) continue;
+ 	    esac
++        # Also skip symlinks following to /nix/store
++        if test -L $path; then
++            case "$(readlink $path)" in
++                @NIX_STORE@/*) continue;
++            esac
++        fi
++
+ 	    # Pick up the flags.
+ 	    case $flags in *u*) upgrade_flag=1;; *) upgrade_flag=;; esac
+ 	    case $flags in *c*) create_flag=1;; *) create_flag=;; esac

--- a/nixos/modules/flyingcircus/packages/postfix/postfix-3.0-no-warnings.patch
+++ b/nixos/modules/flyingcircus/packages/postfix/postfix-3.0-no-warnings.patch
@@ -1,0 +1,86 @@
+diff -ru3 postfix-3.0.3/conf/postfix-script postfix-3.0.3-new/conf/postfix-script
+--- postfix-3.0.3/conf/postfix-script	2014-06-27 18:05:15.000000000 +0400
++++ postfix-3.0.3-new/conf/postfix-script	2016-01-09 17:51:38.545733631 +0300
+@@ -84,24 +84,6 @@
+ 	exit 1
+ }
+ 
+-# If this is a secondary instance, don't touch shared files.
+-
+-instances=`test ! -f $def_config_directory/main.cf ||
+-    $command_directory/postconf -c $def_config_directory \
+-    -h multi_instance_directories | sed 's/,/ /'` || {
+-	$FATAL cannot execute $command_directory/postconf!
+-	exit 1
+-}
+-
+-check_shared_files=1
+-for name in $instances
+-do
+-    case "$name" in
+-    "$def_config_directory") ;;
+-    "$config_directory") check_shared_files=; break;;
+-    esac
+-done
+-
+ #
+ # Parse JCL
+ #
+@@ -262,22 +244,6 @@
+ 	    -prune \( -perm -020 -o -perm -002 \) \
+ 	    -exec $WARN group or other writable: {} \;
+ 
+-	# Check Postfix root-owned directory tree owner/permissions.
+-
+-	todo="$config_directory/."
+-	test -n "$check_shared_files" && {
+-		todo="$daemon_directory/. $meta_directory/. $todo"
+-		test "$shlib_directory" = "no" || 
+-		    todo="$shlib_directory/. $todo"
+-	}
+-	todo=`echo "$todo" | tr ' ' '\12' | sort -u`
+-
+-	find $todo ! -user root \
+-	    -exec $WARN not owned by root: {} \;
+-
+-	find $todo \( -perm -020 -o -perm -002 \) \
+-	    -exec $WARN group or other writable: {} \;
+-
+ 	# Check Postfix mail_owner-owned directory tree owner/permissions.
+ 
+ 	find $data_directory/. ! -user $mail_owner \
+@@ -302,18 +268,11 @@
+ 	# Check Postfix setgid_group-owned directory and file group/permissions.
+ 
+ 	todo="$queue_directory/public $queue_directory/maildrop"
+-	test -n "$check_shared_files" && 
+-	   todo="$command_directory/postqueue $command_directory/postdrop $todo"
+ 
+ 	find $todo \
+ 	    -prune ! -group $setgid_group \
+ 	    -exec $WARN not owned by group $setgid_group: {} \;
+ 
+-	test -n "$check_shared_files" &&
+-	find $command_directory/postqueue $command_directory/postdrop \
+-	    -prune ! -perm -02111 \
+-	    -exec $WARN not set-gid or not owner+group+world executable: {} \;
+-
+ 	# Check non-Postfix root-owned directory tree owner/content.
+ 
+ 	for dir in bin etc lib sbin usr
+@@ -334,15 +293,6 @@
+ 
+ 	find corrupt -type f -exec $WARN damaged message: {} \;
+ 
+-	# Check for non-Postfix MTA remnants.
+-
+-	test -n "$check_shared_files" -a -f /usr/sbin/sendmail -a \
+-		-f /usr/lib/sendmail && {
+-	    cmp -s /usr/sbin/sendmail /usr/lib/sendmail || {
+-		$WARN /usr/lib/sendmail and /usr/sbin/sendmail differ
+-		$WARN Replace one by a symbolic link to the other
+-	    }
+-	}
+ 	exit 0
+ 	;;
+ 

--- a/nixos/modules/flyingcircus/packages/postfix/postfix-script-shell.patch
+++ b/nixos/modules/flyingcircus/packages/postfix/postfix-script-shell.patch
@@ -1,0 +1,21 @@
+diff --git a/conf/postfix-script b/conf/postfix-script
+index 19088a6..04fae23 100755
+--- a/conf/postfix-script
++++ b/conf/postfix-script
+@@ -43,7 +43,6 @@ FATAL="$LOGGER -p fatal"
+ PANIC="$LOGGER -p panic"
+ 
+ umask 022
+-SHELL=/bin/sh
+ 
+ #
+ # Can't do much without these in place.
+@@ -229,7 +228,7 @@ status)
+ check-fatal)
+ 	# This command is NOT part of the public interface.
+ 
+-	$SHELL $daemon_directory/post-install create-missing || {
++	$daemon_directory/post-install create-missing || {
+ 		$FATAL unable to create missing queue directories
+ 		exit 1
+ 	}

--- a/nixos/modules/flyingcircus/packages/postfix/relative-symlinks.patch
+++ b/nixos/modules/flyingcircus/packages/postfix/relative-symlinks.patch
@@ -1,0 +1,13 @@
+diff --git a/postfix-install b/postfix/postfix-install
+index 1662c3d..0f20ec0 100644
+--- a/postfix-install
++++ b/postfix-install
+@@ -336,7 +336,7 @@ compare_or_symlink() {
+ 	# 2) we cannot use mv to replace a symlink-to-directory;
+ 	# 3) "ln -n" is not in POSIX, therefore it's not portable.
+ 	# rm+ln is less atomic but this affects compatibility symlinks only.
+-	rm -f $2 && ln -sf $link $2 || exit 1
++	rm -f $2 && ln -rsf $link $2 || exit 1
+     }
+ }
+ 

--- a/nixos/modules/flyingcircus/roles/mailserver.nix
+++ b/nixos/modules/flyingcircus/roles/mailserver.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.flyingcircus;
@@ -13,14 +11,25 @@ let
     config.flyingcircus.enc_services;
 
 
+  config_options = [
+    (if lib.pathExists "/etc/local/postfix/local.cf" then
+      lib.readFile /etc/local/postfix/local.cf
+     else "")
+
+    (if lib.pathExists "/etc/local/postfix/canonical.pcre" then
+      "canonical_maps = pcre:${/etc/local/postfix/canonical.pcre}\n"
+     else "")
+
+  ];
+
 in
 {
   options = {
 
     flyingcircus.roles.mailserver = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Enable the Flying Circus mailserver out role and configure
@@ -31,8 +40,9 @@ in
     };
   };
 
-  config = mkMerge [
-    (mkIf cfg.roles.mailserver.enable {
+  config = lib.mkMerge [
+
+   (lib.mkIf cfg.roles.mailserver.enable {
       services.postfix.enable = true;
 
       # Allow all networks on the SRV interface. We expect only trusted machines
@@ -41,9 +51,30 @@ in
         if cfg.enc.parameters.interfaces ? srv
         then builtins.attrNames cfg.enc.parameters.interfaces.srv.networks
         else [];
+
+      system.activationScripts.fcio-postfix = ''
+          install -d -o root -g service  -m 02775 /etc/local/postfix/
+        '';
+
+      environment.etc."local/postfix/README.txt".text = ''
+        Put your local postfix configuration here.
+
+        Use local.cf for pure configuration settings like
+        setting message_size_limit. Please do use normal main.cf syntax,
+        as this will extend the basic configuration file.
+
+        If you need to reference to some map, these are currently available:
+        * canonical.pcre
+
+        In case you need to extend this list, get in contact with our
+        support.
+      '';
+
+      services.postfix.extraConfig = lib.concatStringsSep "\n" config_options;
+
     })
 
-    (mkIf (!cfg.roles.mailserver.enable &&
+    (lib.mkIf (!cfg.roles.mailserver.enable &&
            mail_out_service != null) {
 
       networking.defaultMailServer.directDelivery = true;

--- a/nixos/modules/flyingcircus/roles/mailserver.nix
+++ b/nixos/modules/flyingcircus/roles/mailserver.nix
@@ -5,13 +5,13 @@ let
   cfg = config.flyingcircus;
   fclib = import ../lib;
 
-  mail_out_service = lib.findFirst
+  mailoutService = lib.findFirst
     (s: s.service == "mailserver-mailout")
     null
     config.flyingcircus.enc_services;
 
 
-  config_options = [
+  mainCf = [
     (if lib.pathExists "/etc/local/postfix/local.cf" then
       lib.readFile /etc/local/postfix/local.cf
      else "")
@@ -19,7 +19,6 @@ let
     (if lib.pathExists "/etc/local/postfix/canonical.pcre" then
       "canonical_maps = pcre:${/etc/local/postfix/canonical.pcre}\n"
      else "")
-
   ];
 
 in
@@ -52,6 +51,11 @@ in
         then builtins.attrNames cfg.enc.parameters.interfaces.srv.networks
         else [];
 
+      # XXX change to fcio.net once #14970 is solved
+      services.postfix.domain = "gocept.net";
+
+      services.postfix.extraConfig = lib.concatStringsSep "\n" mainCf;
+
       system.activationScripts.fcio-postfix = ''
           install -d -o root -g service  -m 02775 /etc/local/postfix/
         '';
@@ -59,29 +63,30 @@ in
       environment.etc."local/postfix/README.txt".text = ''
         Put your local postfix configuration here.
 
-        Use local.cf for pure configuration settings like
+        Use `main.cf` for pure configuration settings like
         setting message_size_limit. Please do use normal main.cf syntax,
         as this will extend the basic configuration file.
 
         If you need to reference to some map, these are currently available:
-        * canonical.pcre
+        * canonical_maps - /etc/local/postfix/canonical.pcre
 
         In case you need to extend this list, get in contact with our
         support.
       '';
 
-      services.postfix.extraConfig = lib.concatStringsSep "\n" config_options;
+      environment.systemPackages = [ pkgs.mailutils ];
 
     })
 
     (lib.mkIf (!cfg.roles.mailserver.enable &&
-           mail_out_service != null) {
+           mailoutService != null) {
 
       networking.defaultMailServer.directDelivery = true;
-      networking.defaultMailServer.hostName = mail_out_service.address;
+      networking.defaultMailServer.hostName = mailoutService.address;
 
       networking.defaultMailServer.root = "admin@flyingcircus.io";
-      networking.defaultMailServer.domain = "fcio.net";
+      # XXX change to fcio.net once #14970 is solved
+      networking.defaultMailServer.domain = "gocept.net";
 
       # Other parts of nixos (cron, mail) expect a suidwrapper for sendmail.
       services.mail.sendmailSetuidWrapper = {

--- a/nixos/release-flyingcircus.nix
+++ b/nixos/release-flyingcircus.nix
@@ -189,11 +189,12 @@ in rec {
       tarball
       vim;
 
-      powerdns = pkgs.callPackage ./modules/flyingcircus/packages/powerdns.nix { };
       influxdb011 = pkgs.callPackage ./modules/flyingcircus/packages/influxdb.nix { };
       mongodb32 = pkgs.callPackage ./modules/flyingcircus/packages/mongodb {
         sasl = pkgs.cyrus_sasl;
       };
+      postfix = pkgs.callPackage ./modules/flyingcircus/packages/postfix/3.0.nix { };
+      powerdns = pkgs.callPackage ./modules/flyingcircus/packages/powerdns.nix { };
 
   };
 


### PR DESCRIPTION
@flyingcircusio/release-managers 

This pull request extends the mailserver role to allow contributing a custom local.cf to postfix as well as adding a canonical.pcre file for e.g. redirecting mails. Also it updates the used Postfix to 3.0.3
