### PR TITLE
Match default configuration of varnish tools (varnishstat, varnishlog, etc.) with VSM location so that they work out of the box (#21977)

### DIFF
--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -264,6 +264,11 @@ in
             )
           ";
         });
+        varnish = pkgs.varnish.overrideDerivation (oldattrs: {
+          configureFlagsArray = [
+            "--localstatedir=/var/spool"
+          ];
+        });
       };
 
     environment.etc = (

--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -34,14 +34,15 @@ in
 {
 
   imports = [
+    ./firewall.nix
     ./logrotate
     ./network.nix
-    ./firewall.nix
+    ./packages.nix
     ./sensu-client.nix
     ./ssl/certificate.nix
     ./ssl/dhparams.nix
-    ./user.nix
     ./systemd.nix
+    ./user.nix
   ];
 
   options = {
@@ -163,69 +164,6 @@ in
     services.cron.enable = true;
     sound.enable = false;
     fonts.fontconfig.enable = true;
-    environment.systemPackages = with pkgs; [
-        apacheHttpd
-        atop
-        bc
-        bind
-        bundler
-        curl
-        cyrus_sasl
-        db
-        dstat
-        fcmaintenance
-        file
-        fio
-        gcc
-        gdbm
-        git
-        gnupg
-        go
-        gptfdisk
-        graphviz
-        imagemagick
-        iotop
-        kerberos
-        libjpeg
-        libmemcached
-        libxml2
-        libxslt
-        links
-        lsof
-        lynx
-        mercurial
-        mmv
-        nano
-        nc6
-        ncdu
-        netcat
-        ngrep
-        nmap
-        nodejs
-        openldap
-        openssl
-        php
-        postgresql
-        protobuf
-        psmisc
-        pv
-        python2Full
-        pythonPackages.virtualenv
-        python34
-        screen
-        strace
-        subversion
-        sysstat
-        tcpdump
-        telnet
-        traceroute
-        tree
-        unzip
-        vim
-        xfsprogs
-        zlib
-    ];
-
     programs.zsh.enable = true;
 
     environment.pathsToLink = [ "/include" ];
@@ -242,34 +180,6 @@ in
     '';
 
     boot.kernelPackages = pkgs.linuxPackages_4_3;
-
-    nixpkgs.config.packageOverrides = pkgs:
-      { linux_4_3 = pkgs.linux_4_3.override {
-          extraConfig =
-            ''
-              DEBUG_INFO y
-              IP_MULTIPLE_TABLES y
-              IPV6_MULTIPLE_TABLES y
-              LATENCYTOP y
-              SCHEDSTATS y
-            '';
-        };
-        nagiosPluginsOfficial = pkgs.nagiosPluginsOfficial.overrideDerivation (oldAttrs: {
-          buildInputs = [ pkgs.openssh pkgs.openssl ];
-          preConfigure= "
-            configureFlagsArray=(
-              --with-openssl=${pkgs.openssl}
-              --with-ping-command='/var/setuid-wrappers/ping -n -w %d -c %d %s'
-              --with-ping6-command='/var/setuid-wrappers/ping6 -n -w %d -c %d %s'
-            )
-          ";
-        });
-        varnish = pkgs.varnish.overrideDerivation (oldattrs: {
-          configureFlagsArray = [
-            "--localstatedir=/var/spool"
-          ];
-        });
-      };
 
     environment.etc = (
       lib.optionalAttrs (lib.hasAttrByPath ["parameters" "directory_secret"] cfg.enc)

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -1,0 +1,100 @@
+{ pkgs, ... }:
+
+{
+  config = {
+
+    environment.systemPackages = with pkgs; [
+        apacheHttpd
+        atop
+        bc
+        bind
+        bundler
+        curl
+        cyrus_sasl
+        db
+        dstat
+        fcmaintenance
+        file
+        fio
+        gcc
+        gdbm
+        git
+        gnupg
+        go
+        gptfdisk
+        graphviz
+        imagemagick
+        iotop
+        kerberos
+        libjpeg
+        libmemcached
+        libxml2
+        libxslt
+        links
+        lsof
+        lynx
+        mercurial
+        mmv
+        nano
+        nc6
+        ncdu
+        netcat
+        ngrep
+        nmap
+        nodejs
+        openldap
+        openssl
+        php
+        postgresql
+        protobuf
+        psmisc
+        pv
+        python2Full
+        pythonPackages.virtualenv
+        python34
+        screen
+        strace
+        subversion
+        sysstat
+        tcpdump
+        telnet
+        traceroute
+        tree
+        unzip
+        vim
+        xfsprogs
+        zlib
+    ];
+
+    nixpkgs.config.packageOverrides = pkgs: {
+      linux_4_3 = pkgs.linux_4_3.override {
+        extraConfig = ''
+          DEBUG_INFO y
+          IP_MULTIPLE_TABLES y
+          IPV6_MULTIPLE_TABLES y
+          LATENCYTOP y
+          SCHEDSTATS y
+        '';
+      };
+
+      nagiosPluginsOfficial =
+        pkgs.nagiosPluginsOfficial.overrideDerivation (oldAttrs: {
+          buildInputs = [ pkgs.openssh pkgs.openssl ];
+          preConfigure= "
+            configureFlagsArray=(
+              --with-openssl=${pkgs.openssl}
+              --with-ping-command='/var/setuid-wrappers/ping -n -w %d -c %d %s'
+              --with-ping6-command='/var/setuid-wrappers/ping6 -n -w %d -c %d %s'
+            )
+          ";
+        });
+
+      varnish = pkgs.varnish.overrideDerivation (oldattrs: {
+        configureFlagsArray = [
+          "--localstatedir=/var/spool"
+        ];
+      });
+    };
+
+  };
+}

--- a/nixos/modules/flyingcircus/roles/webproxy.nix
+++ b/nixos/modules/flyingcircus/roles/webproxy.nix
@@ -36,6 +36,7 @@ in
     services.varnish.enable = true;
     services.varnish.http_address = "localhost:8008";
     services.varnish.config = varnishCfg;
+    services.varnish.stateDir = "/var/spool/varnish/${config.networking.hostName}";
 
     system.activationScripts.varnish = ''
       install -d -o ${toString config.ids.uids.varnish} -g service -m 02775 /etc/local/varnish


### PR DESCRIPTION
@flyingcircusio/release-managers

re #21977

changelog: Add webproxy role for nixos (varnish, #21977)