### PR TITLE
Using /etc/local/postfix/myhostname to configure myhostname on Postfix' main.cf (#23084)

### DIFF
--- a/nixos/modules/flyingcircus/roles/mailserver.nix
+++ b/nixos/modules/flyingcircus/roles/mailserver.nix
@@ -10,6 +10,7 @@ let
     null
     config.flyingcircus.enc_services;
 
+  myHostname = (fclib.configFromFile /etc/local/postfix/myhostname "");
 
   mainCf = [
     (if lib.pathExists "/etc/local/postfix/local.cf" then
@@ -53,6 +54,8 @@ in
 
       # XXX change to fcio.net once #14970 is solved
       services.postfix.domain = "gocept.net";
+
+      services.postfix.hostname = myHostname;
 
       services.postfix.extraConfig = lib.concatStringsSep "\n" mainCf;
 

--- a/nixos/modules/flyingcircus/roles/mailserver.nix
+++ b/nixos/modules/flyingcircus/roles/mailserver.nix
@@ -70,6 +70,10 @@ in
         setting message_size_limit. Please do use normal main.cf syntax,
         as this will extend the basic configuration file.
 
+        Make usage of `myhostname` to provide a hostname Postfix shall
+        use to configure its own myhostname variable. If not set, the
+        default hostname will be used instead.
+
         If you need to reference to some map, these are currently available:
         * canonical_maps - /etc/local/postfix/canonical.pcre
 


### PR DESCRIPTION
@flyingcircusio/release-managers 

This PR allows service users to set myhostname via /etc/local/postfix/myhostname

