### PR TITLE
23179 fix redis warnings

### DIFF
--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -55,6 +55,10 @@ in
       fi
     '';
 
+    systemd.services.redis = {
+      serviceConfig.LimitNOFILE = 64000;
+    };
+
     flyingcircus.services.sensu-client.checks = {
       redis = {
         notification = "Redis alive";

--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -56,10 +56,13 @@ in
     '';
 
     systemd.services.redis = {
-      serviceConfig.LimitNOFILE = 64000;
-      preStart = "echo never > /sys/kernel/mm/transparent_hugepage/defrag";
-      postStop = "echo always > /sys/kernel/mm/transparent_hugepage/defrag";
-      serviceConfig.PermissionsStartOnly = true;
+      serviceConfig = {
+        LimitNOFILE = 64000;
+        PermissionsStartOnly = true;
+      };
+
+      preStart = "echo never > /sys/kernel/mm/transparent_hugepage/enabled";
+      postStop = "echo madvise > /sys/kernel/mm/transparent_hugepage/enabled";
     };
 
     flyingcircus.services.sensu-client.checks = {

--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -57,6 +57,9 @@ in
 
     systemd.services.redis = {
       serviceConfig.LimitNOFILE = 64000;
+      preStart = "echo never > /sys/kernel/mm/transparent_hugepage/defrag";
+      postStop = "echo always > /sys/kernel/mm/transparent_hugepage/defrag";
+      serviceConfig.PermissionsStartOnly = true;
     };
 
     flyingcircus.services.sensu-client.checks = {


### PR DESCRIPTION
@flyingcircusio/release-managers

This PR fixes a few warnings popped up during startup of Redis: 
- Increase of allowed file descriptors 
- Disable Transparent Huge Pages