### PR TITLE
Ensure /etc/local/redis/password is owned by redis:service (#23116)

### DIFF
--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -51,10 +51,12 @@ in
       install -d -o ${toString config.ids.uids.redis} -g service -m 02775 \
         /etc/local/redis/
       if [[ ! -e /etc/local/redis/password ]]; then
-        (umask 007;
-         echo ${lib.escapeShellArg password} > /etc/local/redis/password;
-         chown redis:service  /etc/local/redis/password;)
+        ( umask 007;
+          echo ${lib.escapeShellArg password} > /etc/local/redis/password
+          chown redis:service /etc/local/redis/password
+        )
       fi
+      chmod 0660 /etc/local/redis/password
     '';
 
     systemd.services.redis = {

--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -51,7 +51,9 @@ in
       install -d -o ${toString config.ids.uids.redis} -g service -m 02775 \
         /etc/local/redis/
       if [[ ! -e /etc/local/redis/password ]]; then
-        (umask 027; echo ${lib.escapeShellArg password} > /etc/local/redis/password)
+        (umask 007;
+         echo ${lib.escapeShellArg password} > /etc/local/redis/password;
+         chown redis:service  /etc/local/redis/password;)
       fi
     '';
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Also this ensures both, redis as well as group service have permission for rw on that file. 

Re #23116