### PR TITLE
Postfix: Fix setting of IPv6 addresses in mynetworks (#23236)

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -17,6 +17,7 @@ let
 
       mail_owner = ${user}
       default_privs = nobody
+      data_directory = /var/postfix/data
 
     ''
     + optionalString config.networking.enableIPv6 ''


### PR DESCRIPTION
changelog: Postfix: Fix setting of IPv6 addresses in mynetworks (#23236)

@flyingcircusio/release-managers

Also set data-dir to /var/postfix as all the other files. If /var/lib/postfix is not there already startup fails otherwise. The path/behaviour might have chaned with the update to 3.0 and we did not set up a new postfix since then.

re #23236