### PR TITLE
Varnish listens on ethsrv as well now. Before it was only listening on 127.0.0.1. (#23196)

### DIFF
--- a/nixos/modules/flyingcircus/lib/network.nix
+++ b/nixos/modules/flyingcircus/lib/network.nix
@@ -38,6 +38,14 @@ rec {
           (map (addr: addr.address) interface_config.ip6)
       else [];
 
+    listenAddressesQuotedV6 = config: interface:
+      map
+        (addr:
+          if isIp6 addr then
+            "[${addr}]"
+          else addr)
+        (listenAddresses config interface);
+
   /*
    * policy routing
    */

--- a/nixos/modules/flyingcircus/roles/webproxy.nix
+++ b/nixos/modules/flyingcircus/roles/webproxy.nix
@@ -33,7 +33,11 @@ in
   config = mkIf cfg.enable {
 
     services.varnish.enable = true;
-    services.varnish.http_address = "localhost:8008";
+    services.varnish.http_address =
+      lib.concatMapStringsSep ","
+        (addr: "${addr}:8008")
+        ((fclib.listenAddressesQuotedV6 config "ethsrv") ++
+         (fclib.listenAddressesQuotedV6 config "lo"));
     services.varnish.config = varnishCfg;
     services.varnish.stateDir = "/var/spool/varnish/${config.networking.hostName}";
 


### PR DESCRIPTION
Changelog: Varnish listens on SRV as well now. Before it was only listening on 127.0.0.1 (#23196)
Impact: Varnish will be restarted.


@flyingcircusio/release-managers 

re #23196