### PR TITLE
increase expected load to the values from the gentoo world.

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -206,7 +206,7 @@ in {
     flyingcircus.services.sensu-client.checks = {
       load = {
         notification = "Load is too high";
-        command =  "check_load -r -w 2.0,1.3,0.9 -c 4,3,2";
+        command =  "check_load -r -w 5,4,4 -c 8,6,6";
         interval = 10;
       };
       swap = {


### PR DESCRIPTION
@flyingcircusio/release-managers

In contrast to what #23143 says the load is already relative to CPUs (-r flag).

Changelog: none necessary (I think)


re #23143