### PR TITLE
fix postfix local modifications file name

### DIFF
--- a/nixos/modules/flyingcircus/roles/mailserver.nix
+++ b/nixos/modules/flyingcircus/roles/mailserver.nix
@@ -18,8 +18,8 @@ let
     else address;
 
   mainCf = [
-    (if lib.pathExists "/etc/local/postfix/local.cf" then
-      lib.readFile /etc/local/postfix/local.cf
+    (if lib.pathExists "/etc/local/postfix/main.cf" then
+      lib.readFile /etc/local/postfix/main.cf
      else "")
 
     (if lib.pathExists "/etc/local/postfix/canonical.pcre" then


### PR DESCRIPTION
@flyingcircusio/release-managers

The readme says `main.cf` and that makes sense. It could happen we would like to customize `master.cf` in the future. A `local.cf` would be pretty stupid then.

re #23458

changelog: Fix postfix' local customization filename to `main.cf` (#23458)
impact: If you have customized postfix with a `/etc/local/postfix/local.cf` copy it over to `/etc/local/postfix/main.cf` before the release. You ran remove `local.cf` after the release. Be sure to also change automatic deployment procedures accordingly.