### PR TITLE
resolve multiple ips for one host from /etc/hosts

### DIFF
--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -104,6 +104,10 @@ in
 
   config = rec {
     environment.etc."iproute2/rt_tables".text = rt_tables;
+    environment.etc."host.conf".text = ''
+      order hosts, bind
+      multi on
+    '';
 
     services.udev.extraRules =
       if (interfaces != {}) then
@@ -154,6 +158,10 @@ in
         then fclib.policyRouting
         else fclib.simpleRouting;
       in
+      { nscd.restartTriggers = [
+          config.environment.etc."host.conf".source
+        ];
+      } //
       listToAttrs
         (map
           (vlan: lib.nameValuePair


### PR DESCRIPTION
@flyingcircusio/release-managers

re #23464

changelog: Fix resolving IP addresses from /etc/hosts entries for hosts with more than one IP address (#23464).