### PR TITLE
Security: disable TCP challenge ACK limit (CVE-2016-5696, #23260)

### DIFF
--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -236,6 +236,9 @@ in
     boot.kernel.sysctl = {
       "net.ipv4.ip_local_port_range" = "32768 60999";
       "net.ipv4.ip_local_reserved_ports" = "61000-61999";
+      # work around CVE-2016-5696
+      # obsolete on Linux 4.7+
+      "net.ipv4.tcp_challenge_ack_limit" = "999999999";
     };
   };
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

Raise TCP challenge ACK limit. This workaround can be reversed once
Linux 4.7 is in production.

Fixes #23260