### PR TITLE
need pymysql for monitoring mysql.

### DIFF
--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     pythonPackages.requests
     pythonPackages.pymongo
     pythonPackages.docker
+    pythonPackages.pymysql
   ];
   propagatedBuildInputs = [ python tornado ];
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Changelog: Add mysql support for DataDog agent. This allows to monitor MySQL with DataDog.