### PR TITLE
reduce percona buffer pool to 70% of RAM

### DIFF
--- a/nixos/modules/flyingcircus/roles/mysql.nix
+++ b/nixos/modules/flyingcircus/roles/mysql.nix
@@ -117,7 +117,7 @@ in
         query_cache_size           = 80M
 
         # * InnoDB
-        innodb_buffer_pool_size         = ${toString (current_memory * 80 / 100)}M
+        innodb_buffer_pool_size         = ${toString (current_memory * 70 / 100)}M
         innodb_log_buffer_size          = 64M
         innodb_file_per_table           = 1
         innodb_read_io_threads          = ${toString (cores * 4)}


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: MySQL servers running on NixOS are being restarted. 

Changelog: Reduce MySQL buffer pool from 80% to 70% of RAM. We saw VMs starting to swap and reduce the buffer pool accordingly.