### PR TITLE
Increase kernel loglevel to 4.

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
@@ -41,6 +41,7 @@ in
     '';
 
   boot.blacklistedKernelModules = [ "bochs_drm" ];
+  boot.kernelModules = [ "i6300esb" ];
   boot.initrd.supportedFilesystems = [ "xfs" ];
   boot.kernelParams = [
     # Crash management
@@ -72,7 +73,7 @@ in
   boot.loader.grub.version = 2;
   boot.supportedFilesystems = [ "xfs" ];
   boot.vesa = false;
-  boot.consoleLogLevel = 0;
+  boot.consoleLogLevel = 4;
 
   networking.hostName = if config.flyingcircus.enc ? name
     then config.flyingcircus.enc.name

--- a/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
@@ -73,7 +73,6 @@ in
   boot.loader.grub.version = 2;
   boot.supportedFilesystems = [ "xfs" ];
   boot.vesa = false;
-  boot.consoleLogLevel = 4;
 
   networking.hostName = if config.flyingcircus.enc ? name
     then config.flyingcircus.enc.name


### PR DESCRIPTION
@flyingcircusio/release-managers

At 0 we do not see kernel dumps on the serial console when it's not absolutely
a panic. We've seen VMs that were in a semi-usable state, probably due to
some storage issue, but it's unclear whether Ceph or XFS was at fault.
I'm betting the kernel is saying _something_ but we can't see it.