### PR TITLE
23773 update rabbitmq

### DIFF
--- a/nixos/modules/flyingcircus/packages/rabbitmq_delayed_message_exchange.nix
+++ b/nixos/modules/flyingcircus/packages/rabbitmq_delayed_message_exchange.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   version = "0.0.1";
 
   src = fetchurl {
-    url = "http://www.rabbitmq.com/community-plugins/v3.4.x/rabbitmq_delayed_message_exchange-${version}-rmq3.4.x-9bf265e4.ez";
-    sha256 = "10vfcs1gfpm2f8shm9504y3fbdvzwjmqh5sn3pdzxs38p0kzil2h";
+    url = "http://www.rabbitmq.com/community-plugins/v3.6.x/rabbitmq_delayed_message_exchange-0.0.1.ez";
+    sha256 = "1v46lfidwqzmw37ymipc83r6z4cdjqs0mxgad2bbl3vkj655sjf2";
   };
 
   builder = ./rabbitmq_install_plugin.sh;

--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -12,7 +12,7 @@ let
     builder = builtins.toFile "makePlugins.sh" ''
       source $stdenv/setup
       mkdir -p $out
-      ln -s $server/libexec/rabbitmq/plugins/* $out
+      ln -s $server/plugins/* $out
       for package in $packages
       do
         ln -s $package/* $out

--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl, erlang, python, libxml2, libxslt, xmlto
-, docbook_xml_dtd_45, docbook_xsl, zip, unzip }:
+, docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync }:
 
 stdenv.mkDerivation rec {
   name = "rabbitmq-server-${version}";
 
-  version = "3.4.3";
+  version = "3.6.5";
 
   src = fetchurl {
-    url = "http://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.gz";
-    sha256 = "1mdma4bh6196ix9vhsigb3yav8l5gy2x78nsqxychm4hz5l2vjx6";
+    url = "http://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
+    sha256 = "1v48ay4z8n9q9c8rg7fhrfa4cg2dqiwbjnr3yl5i7xdam0y46l4m";
   };
 
   buildInputs =
-    [ erlang python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip ];
+    [ erlang python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ];
 
   preBuild =
     ''
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       patchShebangs .
     '';
 
-  installFlags = "TARGET_DIR=$(out)/libexec/rabbitmq SBIN_DIR=$(out)/sbin MAN_DIR=$(out)/share/man DOC_INSTALL_DIR=$(out)/share/doc";
+  installFlags = "PREFIX=$(out) RMQ_ERLAPP_DIR=$(out)";
 
   preInstall =
     ''


### PR DESCRIPTION
@flyingcircusio/release-managers

Changelog: Update RabbitMQ to 3.6.5 (#23773)

Impact: RabbitMQ will be restarted.

re #23773