### PR TITLE
removed x11 dependency in gnupg

### DIFF
--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -4,11 +4,6 @@
   config = {
 
     environment.systemPackages = with pkgs;
-    let gnupg_nox11 = lib.overrideDerivation gnupg (attrs: {
-        doCheck = false;
-        x11Support = false;
-    });
-    in
     [
         apacheHttpd
         atop
@@ -25,7 +20,13 @@
         gcc
         gdbm
         git
-        gnupg_nox11
+        (gnupg.override{
+          x11Support = false;
+          pinentry = pkgs.pinentry.override {
+            gtk2 = null;
+            qt4 = null;
+          };
+        })
         go
         gptfdisk
         graphviz

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -3,7 +3,13 @@
 {
   config = {
 
-    environment.systemPackages = with pkgs; [
+    environment.systemPackages = with pkgs;
+    let gnupg_nox11 = lib.overrideDerivation gnupg (attrs: {
+        doCheck = false;
+        x11Support = false;
+    });
+    in
+    [
         apacheHttpd
         atop
         bc
@@ -19,7 +25,7 @@
         gcc
         gdbm
         git
-        (gnupg.override { x11Support = false; })
+        gnupg_nox11
         go
         gptfdisk
         graphviz

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -19,7 +19,7 @@
         gcc
         gdbm
         git
-        gnupg
+        (gnupg.override { x11Support = false; })
         go
         gptfdisk
         graphviz

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
     sha256 = "1338hj1h3sh34897120y30x12b64wyj3xjzzk5asm2hdzhxgsmva";
   };
 
-  buildInputs = [ libgpgerror libassuan libcap gtk2 ncurses qt4 ];
+  buildInputs = [ libgpgerror libassuan libcap ncurses ]
+                ++ optional (gtk2 != null) gtk2
+                ++ optional (qt4 != null) qt4;
 
   prePatch = ''
     substituteInPlace pinentry/pinentry-curses.c --replace ncursesw ncurses


### PR DESCRIPTION
@flyingcircusio/release-managers 

by default gnupg nix expression chained gtk and friends as deps, which lead to excessive rebuild-times.

