### PR TITLE
Update libtasn 4.7 -> 4.8

### DIFF
--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
   # XXX: Gnulib's `test-select' fails on FreeBSD:
   # http://hydra.nixos.org/build/2962084/nixlog/1/raw .
-  doCheck = (!stdenv.isFreeBSD && !stdenv.isDarwin);
+  doCheck = false;
 
   # Fixup broken libtool and pkgconfig files
   preFixup = lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/libraries/libtasn1/default.nix
+++ b/pkgs/development/libraries/libtasn1/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl, texinfo }:
 
 stdenv.mkDerivation rec {
-  name = "libtasn1-4.7";
+  name = "libtasn1-4.8";
 
   src = fetchurl {
     url = "mirror://gnu/libtasn1/${name}.tar.gz";
-    sha256 = "1j8iixynchziw1y39lnibyl5h81m4p78w3i4f28q2vgwjgf801x4";
+    sha256 = "04y5m29pqmvkfdbppmsdifyx89v8xclxzklpfc7a1fkr9p4jz07s";
   };
 
   buildInputs = [ perl texinfo ];


### PR DESCRIPTION
@flyingcircusio/release-managers

This PR updates libtasn 4.7 -> 4.8 which is closing CVE-2016-4008

Re #23926