### PR TITLE
Remove check for concurrent users from sensu.

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -237,11 +237,6 @@ in {
         command = "check_uptime";
         interval = 300;
       };
-      users = {
-        notification = "Too many users logged in";
-        command = "check_users -w 5 -c 10";
-        interval = 300;
-      };
       systemd_units = {
         notification = "SystemD has failed units";
         command = "check-failed-units.rb";


### PR DESCRIPTION
@flyingcircusio/release-managers

This removes the concurrent users check from sensu as customer might have interest on having 5 or 10 or more users logged in and the check only caused noise in such cases. 

Re #22541