### PR TITLE
Security update for dnsmasq

### DIFF
--- a/nixos/modules/flyingcircus/packages/default.nix
+++ b/nixos/modules/flyingcircus/packages/default.nix
@@ -12,6 +12,8 @@
 
     cron = pkgs.callPackage ./cron.nix { };
 
+    dnsmasq = pkgs.callPackage ./dnsmasq.nix { };
+
     easyrsa3 = pkgs.callPackage ./easyrsa { openssl = pkgs.openssl_1_0_2; };
 
     fcmaintenance = pkgs.callPackage ./fcmaintenance { };

--- a/nixos/modules/flyingcircus/packages/dnsmasq.nix
+++ b/nixos/modules/flyingcircus/packages/dnsmasq.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchurl, pkgconfig, dbus_libs, nettle, libidn, libnetfilter_conntrack }:
+
+with stdenv.lib;
+let
+  copts = concatStringsSep " " ([
+    "-DHAVE_IDN"
+    "-DHAVE_DNSSEC"
+  ] ++ optionals stdenv.isLinux [
+    "-DHAVE_DBUS"
+    "-DHAVE_CONNTRACK"
+  ]);
+in
+stdenv.mkDerivation rec {
+  name = "dnsmasq-2.76";
+
+  src = fetchurl {
+    url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.xz";
+    sha256 = "15lzih6671gh9knzpl8mxchiml7z5lfqzr7jm2r0rjhrxs6nk4jb";
+  };
+
+  preBuild = ''
+    makeFlagsArray=("COPTS=${copts}")
+  '';
+
+  makeFlags = [
+    "DESTDIR="
+    "BINDIR=$(out)/bin"
+    "MANDIR=$(out)/man"
+    "LOCALEDIR=$(out)/share/locale"
+  ];
+
+  hardeningEnable = [ "pie" ];
+
+  postBuild = optionalString stdenv.isLinux ''
+    make -C contrib/lease-tools
+  '';
+
+  # XXX: Does the systemd service definition really belong here when our NixOS
+  # module can create it in Nix-land?
+  postInstall = ''
+    install -Dm644 trust-anchors.conf $out/share/dnsmasq/trust-anchors.conf
+  '' + optionalString stdenv.isLinux ''
+    install -Dm644 dbus/dnsmasq.conf $out/etc/dbus-1/system.d/dnsmasq.conf
+    install -Dm755 contrib/lease-tools/dhcp_lease_time $out/bin/dhcp_lease_time
+    install -Dm755 contrib/lease-tools/dhcp_release $out/bin/dhcp_release
+    install -Dm755 contrib/lease-tools/dhcp_release6 $out/bin/dhcp_release6
+
+    mkdir -p $out/share/dbus-1/system-services
+    cat <<END > $out/share/dbus-1/system-services/uk.org.thekelleys.dnsmasq.service
+    [D-BUS Service]
+    Name=uk.org.thekelleys.dnsmasq
+    Exec=$out/bin/dnsmasq -k -1
+    User=root
+    SystemdService=dnsmasq.service
+    END
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ nettle libidn ]
+    ++ optionals stdenv.isLinux [ dbus_libs libnetfilter_conntrack ];
+
+  meta = {
+    description = "An integrated DNS, DHCP and TFTP server for small networks";
+    homepage = http://www.thekelleys.org.uk/dnsmasq/doc.html;
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ eelco fpletz ];
+  };
+}

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -69,6 +69,8 @@
     ];
 
     nixpkgs.config.packageOverrides = pkgs: {
+      collectd = pkgs.collectd.override { libvirt = null; };
+
       linux_4_3 = pkgs.linux_4_3.override {
         extraConfig = ''
           DEBUG_INFO y
@@ -80,9 +82,9 @@
       };
 
       nagiosPluginsOfficial =
-        pkgs.nagiosPluginsOfficial.overrideDerivation (oldAttrs: {
+        pkgs.nagiosPluginsOfficial.overrideDerivation (old: {
           buildInputs = [ pkgs.openssh pkgs.openssl pkgs.perl ];
-          preConfigure= "
+          preConfigure= ''
             configureFlagsArray=(
               --with-openssl=${pkgs.openssl}
               --with-ping-command='/var/setuid-wrappers/ping -n -w %d -c %d %s'
@@ -91,7 +93,7 @@
               # be run, some mailer daemon needs to be installed.
               --with-mailq-command=/run/current-system/sw/bin/mailq
             )
-          ";
+          '';
         });
 
       varnish =

--- a/nixos/modules/flyingcircus/roles/external_net/vxlan.nix
+++ b/nixos/modules/flyingcircus/roles/external_net/vxlan.nix
@@ -71,7 +71,7 @@ let
       dhcp-option=option:mtu,${toString mtu}
       dhcp-option=option:ntp-server,0.0.0.0
       dhcp-range=::,constructor:${dev},ra-names
-      dhcp-range=${lib.concatStringsSep "," params.dhcp},4h
+      dhcp-range=${lib.concatStringsSep "," params.dhcp},24h
       domain=ext.${domain}
       domain-needed
       interface=ethfe,${dev}


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: Security update for dnsmasq (CVE-2015-8899, #23865).

Updating dnsmasq to 2.76.

CVE-2015-8899

Fixes #23865