### PR TITLE
24271 dirty cow linux 4.4.27

### DIFF
--- a/nixos/modules/flyingcircus/packages/default.nix
+++ b/nixos/modules/flyingcircus/packages/default.nix
@@ -31,7 +31,6 @@
           pkgs.kernelPatches.mips_ext3_n32
         ];
       extraConfig =  ''
-          DEBUG_INFO y
           IP_MULTIPLE_TABLES y
           IPV6_MULTIPLE_TABLES y
           LATENCYTOP y

--- a/nixos/modules/flyingcircus/packages/default.nix
+++ b/nixos/modules/flyingcircus/packages/default.nix
@@ -21,6 +21,27 @@
     fcsensuplugins = pkgs.callPackage ./fcsensuplugins { };
     fcutil = pkgs.callPackage ./fcutil { };
 
+    linux_4_4 = pkgs.callPackage ./linux-4.4.nix {
+      kernelPatches =
+        [ pkgs.kernelPatches.bridge_stp_helper
+        ]
+        ++ pkgs.lib.optionals ((pkgs.platform.kernelArch or null) == "mips")
+        [ pkgs.kernelPatches.mips_fpureg_emu
+          pkgs.kernelPatches.mips_fpu_sigill
+          pkgs.kernelPatches.mips_ext3_n32
+        ];
+      extraConfig =  ''
+          DEBUG_INFO y
+          IP_MULTIPLE_TABLES y
+          IPV6_MULTIPLE_TABLES y
+          LATENCYTOP y
+          SCHEDSTATS y
+          '';
+    };
+
+    linuxPackages_4_4 = pkgs.recurseIntoAttrs
+      (pkgs.linuxPackagesFor linux_4_4 linuxPackages_4_4);
+
     mc = pkgs.callPackage ./mc.nix { };
     mailx = pkgs.callPackage ./mailx.nix { };
     mongodb32 = pkgs.callPackage ./mongodb { sasl = pkgs.cyrus_sasl; };

--- a/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/resize.py
+++ b/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/resize.py
@@ -9,6 +9,7 @@ import fc.maintenance
 import fc.maintenance.lib.reboot
 import fc.manage.dmi_memory
 import json
+import os
 import os.path
 import re
 import shutil
@@ -150,7 +151,7 @@ class Disk(object):
             return
         print('resize: Setting XFS quota limits to {} GiB'.format(disk_gb))
         print(self.xfsq('project -s {}'.format(self.proj), ionice=True))
-        print(self.xfsq('timer -p 1m' ))
+        print(self.xfsq('timer -p 1m'))
         print(self.xfsq('limit -p bsoft={d}g bhard={d}g {p}'.format(
             d=disk_gb, p=self.proj)))
 

--- a/nixos/modules/flyingcircus/packages/linux-4.4.nix
+++ b/nixos/modules/flyingcircus/packages/linux-4.4.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+
+import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
+  version = "4.4.27";
+  extraMeta.branch = "4.4";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
+    sha256 = "1zbahhbwxdhl7v0l2ch1ybllywj2df3rmy8w451whr79z7c7shvc";
+  };
+
+  kernelPatches = args.kernelPatches;
+
+  features.iwlwifi = false;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+} // (args.argsOverride or {}))

--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -182,13 +182,13 @@ in
       TMOUT=43200
     '';
 
-    boot.kernelPackages = pkgs.linuxPackages_4_3;
+    boot.kernelPackages = pkgs.linuxPackages_4_4;
 
     environment.etc = (
       lib.optionalAttrs (lib.hasAttrByPath ["parameters" "directory_secret"] cfg.enc)
       { "directory.secret".text = cfg.enc.parameters.directory_secret;
         "directory.secret".mode = "0600";}) //
-      { "nixos/configuration.nix".text = lib.readFile ../files/etc_nixos_configuration.nix; };
+      { "nixos/configuration.nix".text = pkgs.lib.readFile ../files/etc_nixos_configuration.nix; };
 
     services.openssh = {
       enable = true;

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -69,17 +69,8 @@
     ];
 
     nixpkgs.config.packageOverrides = pkgs: {
-      collectd = pkgs.collectd.override { libvirt = null; };
 
-      linux_4_3 = pkgs.linux_4_3.override {
-        extraConfig = ''
-          DEBUG_INFO y
-          IP_MULTIPLE_TABLES y
-          IPV6_MULTIPLE_TABLES y
-          LATENCYTOP y
-          SCHEDSTATS y
-        '';
-      };
+      collectd = pkgs.collectd.override { libvirt = null; };
 
       nagiosPluginsOfficial =
         pkgs.nagiosPluginsOfficial.overrideDerivation (old: {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -264,7 +264,7 @@ with stdenv.lib;
   MICROCODE y
   MICROCODE_INTEL y
   MICROCODE_AMD y
-  ${optionalString (versionAtLeast version "3.11") ''
+  ${optionalString (versionAtLeast version "3.11" && versionOlder version "4.4") ''
     MICROCODE_EARLY y
     MICROCODE_INTEL_EARLY y
     MICROCODE_AMD_EARLY y
@@ -279,7 +279,9 @@ with stdenv.lib;
   ${optionalString (versionAtLeast version "3.3" && versionOlder version "3.13") ''
     AUDIT_LOGINUID_IMMUTABLE y
   ''}
-  B43_PCMCIA? y
+  ${optionalString (versionOlder version "4.4") ''
+    B43_PCMCIA? y
+  ''}
   BLK_DEV_CMD640_ENHANCED y # CMD640 enhanced support
   BLK_DEV_IDEACPI y # IDE ACPI support
   BLK_DEV_INTEGRITY y


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: All NixOS VMs will be rebooted due to a kernel update (4.4.27) to fix the "Dirty Cow" security issue.

Changelog:

* Update Linux kernel to 4.4.27
* Automatically detect kernel changes and schedule maintenance for reboots to activate them.