### PR TITLE
moved gids to static/user.nix, fixed the gid ordering

### DIFF
--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -56,9 +56,9 @@ let
   admins_group =
     if admins_group_data == null
     then {}
-    else {
-      ${admins_group_data.name}.gid = admins_group_data.gid;
-    };
+    else
+      lib.setAttrByPath [ admins_group_data.name "gid" ]  admins_group_data.gid;
+
 
   current_rg =
     if lib.hasAttrByPath ["parameters" "resource_group"] cfg.enc
@@ -94,7 +94,7 @@ let
           (permission: {
             name = permission.name;
             value = {
-              gid = config.ids.gids.${permission.name};
+              gid = cfg.static.ids.gids.${permission.name};
             };
           })
           permissions));
@@ -150,7 +150,6 @@ in
 
 
   config = {
-
     ids.uids = {
       # Our custom services
       sensuserver = 31001;
@@ -193,10 +192,10 @@ in
       mutableUsers = false;
       users = map_userdata userdata;
       groups =
-        get_permission_groups permissions
-        // { service.gid = config.ids.gids.service; }
-        // admins_group
-        // get_group_memberships userdata;
+        admins_group
+        // get_group_memberships userdata
+        // { service.gid = cfg.static.ids.gids.service; }
+        // get_permission_groups permissions;
     };
 
     # needs to be first in sudoers because of the %admins rule

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -162,11 +162,11 @@ in {
         }
     '';
 
-    users.extraGroups.sensuclient.gid = config.ids.gids.sensuclient;
+    users.extraGroups.sensuclient.gid = config.flyingcircus.static.ids.gids.sensuclient;
 
     users.extraUsers.sensuclient = {
       description = "sensu client daemon user";
-      uid = config.ids.uids.sensuclient;
+      uid = config.flyingcircus.static.ids.uids.sensuclient;
       group = "sensuclient";
       # Allow sensuclient to interact with services. This especially helps to
       # check supervisor with a group-writable socket:

--- a/nixos/modules/flyingcircus/static/default.nix
+++ b/nixos/modules/flyingcircus/static/default.nix
@@ -95,5 +95,32 @@ with lib;
       vagrant = true;
     };
 
+    flyingcircus.static.ids.uids = {
+      # Our custom services
+      sensuserver = 31001;
+      sensuapi = 31002;
+      uchiwa = 31003;
+      sensuclient = 31004;
+      powerdns = 31005;
+    };
+
+    flyingcircus.static.ids.gids = {
+      # The generic 'service' GID is different from Gentoo.
+      # But 101 is already used in NixOS.
+      service = 900;
+
+      # Our permissions
+      login = 500;
+      code = 501;
+      stats = 502;
+      sudo-srv = 503;
+
+      # Our custom services
+      sensuserver = 31001;
+      sensuapi = 31002;
+      uchiwa = 31003;
+      sensuclient = 31004;
+    };
+
   };
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: gids of already existing groups **aren't** changed. A warning conveys this fact. Needs a rebuilt of the Image

Changelog: gids of users/static.nix are respected.

re #21537
