### PR TITLE
use --build by default

### DIFF
--- a/nixos/modules/flyingcircus/services/fcmanage.nix
+++ b/nixos/modules/flyingcircus/services/fcmanage.nix
@@ -20,7 +20,7 @@ in {
 
       steps = mkOption {
         type = types.str;
-        default = "--directory --system-state --maintenance --channel";
+        default = "--directory --system-state --maintenance --build";
         description = "Steps to run by the agent.";
       };
     };


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: n/a
Changelog: n/a


This allows to develop and/or switch machines to dev w/o fiddling around with local.nix