### PR TITLE
collectd uptime every 5 minutes instead every 5 seconds

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
@@ -20,9 +20,12 @@ mkIf (params ? location && params ? resource_group) {
     LoadPlugin processes
     LoadPlugin swap
     LoadPlugin syslog
-    LoadPlugin uptime
     LoadPlugin vmem
     LoadPlugin write_graphite
+
+    <LoadPlugin uptime>
+      Interval 360
+    </LoadPlugin>
 
     <Plugin "syslog">
         LogLevel info


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: none

It's quite useles to have 5s interval for uptime and it wastes space and bandwidth.