### PR TITLE
Fix check_journal encoding issue

### DIFF
--- a/nixos/modules/flyingcircus/services/fcmanage.nix
+++ b/nixos/modules/flyingcircus/services/fcmanage.nix
@@ -48,6 +48,7 @@ in {
           inherit (config.environment.sessionVariables) NIX_PATH SSL_CERT_FILE;
           HOME = "/root";
           PATH = "/run/current-system/sw/sbin:/run/current-system/sw/bin";
+          LANG = "en_US.utf8";
         };
         script = ''
           failed=0
@@ -77,7 +78,6 @@ in {
         description = "Timer for fc-manage";
         wantedBy = [ "timers.target" ];
         timerConfig = {
-          Unit = "fc-manage.service";
           OnStartupSec = "10s";
           OnUnitActiveSec = "10m";
           # Not yet supported by our systemd version.

--- a/nixos/modules/flyingcircus/services/sensu/check_journal.yaml
+++ b/nixos/modules/flyingcircus/services/sensu/check_journal.yaml
@@ -8,6 +8,7 @@ criticalpatterns:
       - 'kvm: .* cpu.* unhandled (rd|wr)msr'
 
 criticalexceptions:
+      - '0 failures 0 errors'
       - 'ACPI Error: Method parse/execution failed'
       - '"timestamp":".*","level":"error"'
 
@@ -20,3 +21,4 @@ warningexceptions:
       - '0 failures 0 errors'
       - 'Cannot add dependency job for unit.*quota'
       - '"timestamp":".*","level":"warn"'
+      - 'warning: not applying GID change of group'

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -203,10 +203,11 @@ in {
       };
       environment = {
         EMBEDDED_RUBY = "true";
-        LANG = "en_US.iso88591";
+        LANG = "en_US.utf8";
       };
       preStart = ''
-        /var/setuid-wrappers/sudo install -o sensuclient -g sensuclient -d /var/cache/vulnix
+        /var/setuid-wrappers/sudo install -o sensuclient -g sensuclient \
+          -d /var/cache/vulnix
       '';
     };
 


### PR DESCRIPTION
I think that `journalctl -o json` has a broken output encoding. Instead
of trying to make up a baroque work-around, I'd better revert to plain
text output. `journalctl -o short` preserves UTF-8 encoded special
characters perfectly.

Reduce noisiness by adding `warning: not applying GID change of group
...` to the exclude list.

Also improve check_journal.py sources:

- Do not compile each regexp for each log line -- this is in O(n²).

- Fix spawned journalctl to UTF-8 and decode accordingly.

- Report full log lines including time stamp.

- Refactor repeated code parts in find_hits().

Re #23128

@flyingcircusio/release-managers

Impact:

Changelog: Fix encoding issues in journal check to reduce false positives (#23128)
