### PR TITLE
update expat

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -12,6 +12,7 @@ rec {
 
   easyrsa3 = pkgs.callPackage ./easyrsa { openssl = pkgs.openssl_1_0_2; };
   elasticsearch = pkgs.callPackage ./elasticsearch { };
+  expat = pkgs.callPackage ./expat.nix { };
 
   fcmaintenance = pkgs.callPackage ./fcmaintenance { };
   fcmanage = pkgs.callPackage ./fcmanage { };

--- a/nixos/modules/flyingcircus/packages/expat.nix
+++ b/nixos/modules/flyingcircus/packages/expat.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "expat-2.2.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/expat/${name}.tar.bz2";
+    sha256 = "1zq4lnwjlw8s9mmachwfvfjf2x3lk24jm41746ykhdcvs7r0zrfr";
+  };
+  configureFlags = stdenv.lib.optional stdenv.isFreeBSD "--with-pic";
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.libexpat.org/;
+    description = "A stream-oriented XML parser library written in C";
+    platforms = platforms.all;
+    license = licenses.mit; # expat version
+  };
+}


### PR DESCRIPTION
re #23872

@flyingcircusio/release-managers

Impact: 

Changelog: Update expat library to 2.2.0 fixing CVE-2013-0340 (#23872)