### PR TITLE
Fix NodeJS 6 SSL (#25440)

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -41,6 +41,19 @@ rec {
     openssl = pkgs.openssl_1_0_2;
   };
 
+  openssl = openssl_1_0_1;
+
+  inherit (pkgs.callPackages ./openssl {
+      fetchurl = pkgs.fetchurlBoot;
+      cryptodevHeaders = pkgs.linuxPackages.cryptodev.override {
+        fetchurl = pkgs.fetchurlBoot;
+        onlyHeaders = true;
+      };
+    })
+    openssl_1_0_1
+    openssl_1_0_2
+    openssl_1_1_0;
+
   osm2pgsql = pkgs.callPackage ./osm2pgsql.nix { };
 
   percona = percona57;

--- a/nixos/modules/flyingcircus/packages/nodejs6/default.nix
+++ b/nixos/modules/flyingcircus/packages/nodejs6/default.nix
@@ -43,13 +43,12 @@ in stdenv.mkDerivation {
   patches = stdenv.lib.optional stdenv.isDarwin ./no-xcode.patch;
 
   buildInputs = [ python which ]
-    ++ (optional stdenv.isLinux utillinux)
+    ++ optionals stdenv.isLinux [ utillinux http-parser ]
     ++ optionals stdenv.isDarwin [ pkgconfig openssl libtool ];
   setupHook = ./setup-hook.sh;
 
   enableParallelBuilding = true;
   dontDisableStatic = true;
-  propagatedBuildInputs = [ openssl ];
 
   passthru.interpreterName = "nodejs";
 

--- a/nixos/modules/flyingcircus/packages/openssl/1.0.1-cygwin64.patch
+++ b/nixos/modules/flyingcircus/packages/openssl/1.0.1-cygwin64.patch
@@ -1,0 +1,136 @@
+--- openssl-1.0.1e/config      2014-10-23 15:53:23.436600000 +0200
++++ openssl-1.0.1e/config      2014-10-23 15:55:33.837000000 +0200
+@@ -832,6 +832,7 @@
+   # these are all covered by the catchall below
+   # *-dgux) OUT="dgux" ;;
+   mips-sony-newsos4) OUT="newsos4-gcc" ;;
++  x86_64-*-cygwin) OUT="Cygwin-x86_64" ;;
+   *-*-cygwin_pre1.3) OUT="Cygwin-pre1.3" ;;
+   *-*-cygwin) OUT="Cygwin" ;;
+   t3e-cray-unicosmk) OUT="cray-t3e" ;;
+--- openssl-1.0.1e/Configure	2013-02-17 17:06:18.682058900 -0600
++++ openssl-1.0.1e/Configure	2013-02-17 16:38:08.000000000 -0600
+@@ -550,6 +550,7 @@ my %table=(
+ "Cygwin-pre1.3", "gcc:-DTERMIOS -DL_ENDIAN -fomit-frame-pointer -O3 -m486 -Wall::(unknown):CYGWIN32::BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${no_asm}:win32",
+ "Cygwin", "gcc:-DTERMIOS -DL_ENDIAN -fomit-frame-pointer -O3 -march=i486 -Wall:::CYGWIN32::BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_asm}:coff:dlfcn:cygwin-shared:-D_WINDLL:-shared:.dll.a",
+ "debug-Cygwin", "gcc:-DTERMIOS -DL_ENDIAN -march=i486 -Wall -DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DBN_CTX_DEBUG -DCRYPTO_MDEBUG -DOPENSSL_NO_ASM -g -Wformat -Wshadow -Wmissing-prototypes -Wmissing-declarations -Werror:::CYGWIN32:::${no_asm}:dlfcn:cygwin-shared:-D_WINDLL:-shared:.dll.a",
++"Cygwin-x86_64", "gcc:-DTERMIOS -DL_ENDIAN -O3 -Wall:::CYGWIN32::SIXTY_FOUR_BIT_LONG RC4_CHUNK DES_INT DES_UNROLL:${x86_64_asm}:mingw64:dlfcn:cygwin-shared:-D_WINDLL:-shared:.dll.a",
+ 
+ # NetWare from David Ward (dsward@novell.com)
+ # requires either MetroWerks NLM development tools, or gcc / nlmconv
+@@ -1128,7 +1129,7 @@ foreach (sort @experimental)
+ 
+ my $IsMK1MF=scalar grep /^$target$/,@MK1MF_Builds;
+ 
+-$exe_ext=".exe" if ($target eq "Cygwin" || $target eq "DJGPP" || $target =~ /^mingw/);
++$exe_ext=".exe" if ($target =~ /^Cygwin/ || $target eq "DJGPP" || $target =~ /^mingw/);
+ $exe_ext=".nlm" if ($target =~ /netware/);
+ $exe_ext=".pm"  if ($target =~ /vos/);
+ $openssldir="/usr/local/ssl" if ($openssldir eq "" and $prefix eq "");
+--- openssl-1.0.1e/Makefile.org	2013-02-11 09:26:04.000000000 -0600
++++ openssl-1.0.1e/Makefile.org	2013-02-17 16:38:08.000000000 -0600
+@@ -326,9 +326,9 @@ clean-shared:
+ 			done; \
+ 		fi; \
+ 		( set -x; rm -f lib$$i$(SHLIB_EXT) ); \
+-		if [ "$(PLATFORM)" = "Cygwin" ]; then \
++		case "$(PLATFORM)" in Cygwin*)  \
+ 			( set -x; rm -f cyg$$i$(SHLIB_EXT) lib$$i$(SHLIB_EXT).a ); \
+-		fi; \
++		esac; \
+ 	done
+ 
+ link-shared:
+@@ -571,11 +571,7 @@ install_sw:
+ 		do \
+ 			if [ -f "$$i" -o -f "$$i.a" ]; then \
+ 			(       echo installing $$i; \
+-				if [ "$(PLATFORM)" != "Cygwin" ]; then \
+-					cp $$i $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new; \
+-					chmod 555 $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new; \
+-					mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i; \
+-				else \
++				case "$(PLATFORM)" in Cygwin*) \
+ 					c=`echo $$i | sed 's/^lib\(.*\)\.dll\.a/cyg\1-$(SHLIB_VERSION_NUMBER).dll/'`; \
+ 					cp $$c $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$c.new; \
+ 					chmod 755 $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$c.new; \
+@@ -583,7 +579,12 @@ install_sw:
+ 					cp $$i $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new; \
+ 					chmod 644 $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new; \
+ 					mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i; \
+-				fi ); \
++					;; \
++				*) \
++					cp $$i $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new; \
++					chmod 555 $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new; \
++					mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i.new $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/$$i; \
++				esac ); \
+ 				if expr $(PLATFORM) : 'mingw' > /dev/null; then \
+ 				(	case $$i in \
+ 						*crypto*) i=libeay32.dll;; \
+@@ -643,9 +644,9 @@ install_docs:
+ 	@pod2man="`cd ./util; ./pod2mantest $(PERL)`"; \
+ 	here="`pwd`"; \
+ 	filecase=; \
+-	if [ "$(PLATFORM)" = "DJGPP" -o "$(PLATFORM)" = "Cygwin" -o "$(PLATFORM)" = "mingw" ]; then \
++	case "$(PLATFORM)" in DJGPP|Cygwin*|mingw*) \
+ 		filecase=-i; \
+-	fi; \
++	esac; \
+ 	set -e; for i in doc/apps/*.pod; do \
+ 		fn=`basename $$i .pod`; \
+ 		sec=`$(PERL) util/extract-section.pl 1 < $$i`; \
+--- openssl-1.0.1e/engines/ccgost/Makefile	2013-02-11 09:26:04.000000000 -0600
++++ openssl-1.0.1e/engines/ccgost/Makefile	2013-02-17 17:05:47.759290200 -0600
+@@ -45,7 +45,11 @@ install:
+ 		set -e; \
+ 		echo installing $(LIBNAME); \
+ 		pfx=lib; \
+-		if [ "$(PLATFORM)" != "Cygwin" ]; then \
++		case "$(PLATFORM)" in Cygwin*) \
++			sfx=".so"; \
++			cp cyg$(LIBNAME).dll $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$${pfx}$(LIBNAME)$$sfx.new; \
++			;; \
++		*) \
+ 			case "$(CFLAGS)" in \
+ 			*DSO_BEOS*) sfx=".so";; \
+ 			*DSO_DLFCN*) sfx=`expr "$(SHLIB_EXT)" : '.*\(\.[a-z][a-z]*\)' \| ".so"`;; \
+@@ -54,10 +58,7 @@ install:
+ 			*) sfx=".bad";; \
+ 			esac; \
+ 			cp $${pfx}$(LIBNAME)$$sfx $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$${pfx}$(LIBNAME)$$sfx.new; \
+-		else \
+-			sfx=".so"; \
+-			cp cyg$(LIBNAME).dll $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$${pfx}$(LIBNAME)$$sfx.new; \
+-		fi; \
++		esac; \
+ 		chmod 555 $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$${pfx}$(LIBNAME)$$sfx.new; \
+ 		mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$${pfx}$(LIBNAME)$$sfx.new $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$${pfx}$(LIBNAME)$$sfx; \
+ 	fi
+--- openssl-1.0.1i/engines/Makefile	2014-10-23 16:08:19.360200000 +0200
++++ openssl-1.0.1i/engines/Makefile	2014-10-23 16:10:54.205800000 +0200
+@@ -111,7 +111,11 @@
+ 		for l in $(LIBNAMES); do \
+ 			( echo installing $$l; \
+ 			  pfx=lib; \
+-			  if [ "$(PLATFORM)" != "Cygwin" ]; then \
++			  case "$(PLATFORM)" in Cygwin*) \
++				sfx=".so"; \
++				cp cyg$$l.dll $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx.new; \
++				;; \
++			  *) \
+ 				case "$(CFLAGS)" in \
+ 				*DSO_BEOS*)	sfx=".so";;	\
+ 				*DSO_DLFCN*)	sfx=`expr "$(SHLIB_EXT)" : '.*\(\.[a-z][a-z]*\)' \| ".so"`;;	\
+@@ -120,10 +124,7 @@
+ 				*)		sfx=".bad";;	\
+ 				esac; \
+ 				cp $$pfx$$l$$sfx $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx.new; \
+-			  else \
+-				sfx=".so"; \
+-				cp cyg$$l.dll $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx.new; \
+-			  fi; \
++			  esac; \
+ 			  chmod 555 $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx.new; \
+ 			  mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx.new $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx ); \
+ 		done; \

--- a/nixos/modules/flyingcircus/packages/openssl/darwin-arch.patch
+++ b/nixos/modules/flyingcircus/packages/openssl/darwin-arch.patch
@@ -1,0 +1,12 @@
+diff -ru -x '*~' openssl-1.0.1c-orig/Configure openssl-1.0.1c/Configure
+--- openssl-1.0.1c-orig/Configure	2012-03-14 23:20:40.000000000 +0100
++++ openssl-1.0.1c/Configure	2012-12-18 17:29:30.268090633 +0100
+@@ -579,7 +579,7 @@
+ "darwin64-ppc-cc","cc:-arch ppc64 -O3 -DB_ENDIAN::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${ppc64_asm}:osx64:dlfcn:darwin-shared:-fPIC -fno-common:-arch ppc64 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "darwin-i386-cc","cc:-arch i386 -O3 -fomit-frame-pointer -DL_ENDIAN::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:BN_LLONG RC4_INT RC4_CHUNK DES_UNROLL BF_PTR:".eval{my $asm=$x86_asm;$asm=~s/cast\-586\.o//;$asm}.":macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch i386 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "debug-darwin-i386-cc","cc:-arch i386 -g3 -DL_ENDIAN::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:BN_LLONG RC4_INT RC4_CHUNK DES_UNROLL BF_PTR:${x86_asm}:macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch i386 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+-"darwin64-x86_64-cc","cc:-arch x86_64 -O3 -DL_ENDIAN -Wall::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL:".eval{my $asm=$x86_64_asm;$asm=~s/rc4\-[^:]+//;$asm}.":macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch x86_64 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
++"darwin64-x86_64-cc","cc:-O3 -DL_ENDIAN -Wall::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL:".eval{my $asm=$x86_64_asm;$asm=~s/rc4\-[^:]+//;$asm}.":macosx:dlfcn:darwin-shared:-fPIC -fno-common:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "debug-darwin-ppc-cc","cc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -DB_ENDIAN -g -Wall -O::-D_REENTRANT:MACOSX::BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${ppc32_asm}:osx32:dlfcn:darwin-shared:-fPIC:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ # iPhoneOS/iOS
+ "iphoneos-cross","llvm-gcc:-O3 -isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fomit-frame-pointer -fno-common::-D_REENTRANT:iOS:-Wl,-search_paths_first%:BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${no_asm}:dlfcn:darwin-shared:-fPIC -fno-common:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",

--- a/nixos/modules/flyingcircus/packages/openssl/default.nix
+++ b/nixos/modules/flyingcircus/packages/openssl/default.nix
@@ -1,0 +1,120 @@
+{ stdenv, fetchurl, perl
+, withCryptodev ? false, cryptodevHeaders
+}:
+
+with stdenv.lib;
+
+let
+  opensslCrossSystem = stdenv.cross.openssl.system or
+    (throw "openssl needs its platform name cross building");
+
+  common = { version, sha256 }: stdenv.mkDerivation rec {
+    name = "openssl-${version}";
+
+    src = fetchurl {
+      url = "http://www.openssl.org/source/${name}.tar.gz";
+      inherit sha256;
+    };
+
+    outputs = [ "out" "man" ];
+
+    patches =
+      optional (versionOlder version "1.1.0") ./use-etc-ssl-certs.patch
+      ++ optional stdenv.isCygwin ./1.0.1-cygwin64.patch
+      ++ optional (stdenv.isDarwin || (stdenv ? cross && stdenv.cross.libc == "libSystem")) ./darwin-arch.patch;
+
+    nativeBuildInputs = [ perl ];
+    buildInputs = stdenv.lib.optional withCryptodev cryptodevHeaders;
+
+    # On x86_64-darwin, "./config" misdetects the system as
+    # "darwin-i386-cc".  So specify the system type explicitly.
+    configureScript =
+      if stdenv.system == "x86_64-darwin" then "./Configure darwin64-x86_64-cc"
+      else if stdenv.system == "x86_64-solaris" then "./Configure solaris64-x86_64-gcc"
+      else "./config";
+
+    configureFlags = [
+      "shared"
+      "--libdir=lib"
+      "--openssldir=etc/ssl"
+    ] ++ stdenv.lib.optionals withCryptodev [
+      "-DHAVE_CRYPTODEV"
+      "-DUSE_CRYPTODEV_DIGESTS"
+    ];
+
+    makeFlags = [
+      "MANDIR=$(out)/share/man"
+    ];
+
+    # Parallel building is broken in OpenSSL.
+    enableParallelBuilding = false;
+
+    postInstall = ''
+      # If we're building dynamic libraries, then don't install static
+      # libraries.
+      if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
+          rm "$out/lib/"*.a
+      fi
+
+      # remove dependency on Perl at runtime
+      rm -r $out/etc/ssl/misc $out/bin/c_rehash
+
+      rmdir $out/etc/ssl/{certs,private}
+    '';
+
+    postFixup = ''
+      # Check to make sure we don't depend on perl
+      if grep -r '${perl}' $out; then
+        echo "Found an erroneous dependency on perl ^^^" >&2
+        exit 1
+      fi
+    '';
+
+    setupHook = builtins.toFile "openssl-setup-hook"
+      ''
+        export SSL_CERT_FILE=/no-cert-file.crt
+      '';
+
+    crossAttrs = {
+      # upstream patch: https://rt.openssl.org/Ticket/Display.html?id=2558
+      postPatch = ''
+         sed -i -e 's/[$][(]CROSS_COMPILE[)]windres/$(WINDRES)/' Makefile.shared
+      '';
+      preConfigure=''
+        # It's configure does not like --build or --host
+        export configureFlags="${concatStringsSep " " (configureFlags ++ [ opensslCrossSystem ])}"
+        # WINDRES and RANLIB need to be prefixed when cross compiling;
+        # the openssl configure script doesn't do that for us
+        export WINDRES=${stdenv.cross.config}-windres
+        export RANLIB=${stdenv.cross.config}-ranlib
+      '';
+      configureScript = "./Configure";
+    };
+
+    meta = {
+      homepage = http://www.openssl.org/;
+      description = "A cryptographic library that implements the SSL and TLS protocols";
+      platforms = stdenv.lib.platforms.all;
+      maintainers = [ stdenv.lib.maintainers.simons ];
+      priority = 10; # resolves collision with ‘man-pages’
+    };
+  };
+
+in {
+
+  openssl_1_0_1 = common {
+    version = "1.0.1t";
+    sha256 = "4a6ee491a2fdb22e519c76fdc2a628bb3cec12762cd456861d207996c8a07088";
+  };
+
+  openssl_1_0_2 = common {
+    version = "1.0.2j";
+    sha256 = "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431";
+  };
+
+  openssl_1_1_0 = common {
+    version = "1.1.0c";
+    sha256 = "fc436441a2e05752d31b4e46115eb89709a28aef96d4fe786abe92409b2fd6f5";
+  };
+
+}

--- a/nixos/modules/flyingcircus/packages/openssl/use-etc-ssl-certs.patch
+++ b/nixos/modules/flyingcircus/packages/openssl/use-etc-ssl-certs.patch
@@ -1,0 +1,13 @@
+diff -ru -x '*~' openssl-1.0.1r-orig/crypto/cryptlib.h openssl-1.0.1r/crypto/cryptlib.h
+--- openssl-1.0.1r-orig/crypto/cryptlib.h	2016-01-28 14:38:30.000000000 +0100
++++ openssl-1.0.1r/crypto/cryptlib.h	2016-02-03 12:54:29.193165176 +0100
+@@ -81,8 +81,8 @@
+ 
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+ #  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_FILE          "/etc/ssl/certs/ca-certificates.crt"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ # else
+ #  define X509_CERT_AREA          "SSLROOT:[000000]"

--- a/nixos/modules/flyingcircus/packages/percona/5.6.nix
+++ b/nixos/modules/flyingcircus/packages/percona/5.6.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DWITH_SSL=yes"
-    "-DWITH_EMBEDDED_SERVER=yes"
+    "-DWITH_EMBEDDED_SERVER=no"
     "-DWITH_ZLIB=yes"
     "-DWITH_EDITLINE=bundled"
     "-DHAVE_IPV6=yes"

--- a/nixos/modules/flyingcircus/packages/percona/5.7.nix
+++ b/nixos/modules/flyingcircus/packages/percona/5.7.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DWITH_SSL=yes"
-    "-DWITH_EMBEDDED_SERVER=yes"
+    "-DWITH_EMBEDDED_SERVER=no"
     "-DWITH_ZLIB=yes"
     "-DWITH_EDITLINE=bundled"
     "-DHAVE_IPV6=yes"

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -43,7 +43,7 @@
         nmap
         nodejs
         openldap
-        openssl
+        openssl_1_0_2
         php
         postgresql
         protobuf


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: updates openssl 1.0.2, hence might restart some things. I cannot really see which now, since the rebuild takes ages. Would like to merge to dev ASAP.

Changelog: Fix NodeJS 6 SSL (#25440)
