### PR TITLE
Box automounts

### DIFF
--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -20,9 +20,7 @@ let
     then builtins.fromJSON (builtins.readFile path)
     else default;
 
-  enc =
-    get_json cfg.enc_path
-    (get_json /etc/nixos/enc.json {});
+  enc = get_json cfg.enc_path (get_json /etc/nixos/enc.json {});
 
   enc_addresses.srv = get_json cfg.enc_addresses_path.srv [];
 

--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -181,6 +181,7 @@ in
     '';
 
     boot.kernelPackages = pkgs.linuxPackages_4_4;
+    boot.supportedFilesystems = [ "nfs4" ];
 
     environment.etc = (
       lib.optionalAttrs

--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -39,14 +39,14 @@ let
         (user: {
           name = user.uid;
           value = {
-            createHome = true;
             description = user.name;
             group = get_primary_group user;
             hashedPassword = lib.removePrefix "{CRYPT}" user.password;
             home = user.home_directory;
-            shell = "/run/current-system/sw" + user.login_shell;
-            uid = user.id;
+            isNormalUser = true;
             openssh.authorizedKeys.keys = user.ssh_pubkey;
+            shell = "/run/current-system/sw${user.login_shell}";
+            uid = user.id;
           };
         })
       users);

--- a/nixos/modules/flyingcircus/roles/nfs.nix
+++ b/nixos/modules/flyingcircus/roles/nfs.nix
@@ -66,7 +66,6 @@ in
 
   config = mkMerge [
     (mkIf (cfg.roles.nfs_rg_client.enable && service ? address) {
-      boot.supportedFilesystems = [ "nfs4" ];
       fileSystems = {
         "${mountpoint}/shared" = {
           device = "${service.address}:${export}";
@@ -101,7 +100,6 @@ in
           config.users.users);
       in
       {
-        boot.supportedFilesystems = [ "nfs4" ];
         fileSystems = (listToAttrs
           (map
             (user: nameValuePair

--- a/nixos/modules/flyingcircus/roles/nfs.nix
+++ b/nixos/modules/flyingcircus/roles/nfs.nix
@@ -8,21 +8,21 @@
 with lib;
 
 let
-  cfg = config.flyingcircus.roles;
+  cfg = config.flyingcircus;
   fclib = import ../lib;
 
   service = findFirst
     (s: s.service == "nfs_rg_share-server")
     {}
-    config.flyingcircus.enc_services;
+    cfg.enc_services;
 
   export = "/srv/nfs/shared";
   mountpoint = "/mnt/nfs";
-  mountopts = "rw,soft,intr,rsize=8192,wsize=8192";
+  mountopts = "rw,soft,intr,rsize=8192,wsize=8192,noauto,x-systemd.automount";
 
   service_clients = filter
     (s: s.service == "nfs_rg_share-server")
-    config.flyingcircus.enc_service_clients;
+    cfg.enc_service_clients;
 
   # This is a bit different than on Gentoo. We allow export to all nodes in the
   # RG, regardles of the node actually being a client.
@@ -32,6 +32,9 @@ let
       clientWithFlags = c: "${c.node}(${flags})";
     in
       concatMapStringsSep " " clientWithFlags service_clients;
+
+  boxServer = findFirst (s: s.service == "box-server") {} cfg.enc_services;
+  boxMount = "/mnt/auto/box";
 
 in
 {
@@ -62,13 +65,13 @@ in
   };
 
   config = mkMerge [
-    (mkIf (cfg.nfs_rg_client.enable && service ? address) {
+    (mkIf (cfg.roles.nfs_rg_client.enable && service ? address) {
       boot.supportedFilesystems = [ "nfs4" ];
       fileSystems = {
         "${mountpoint}/shared" = {
           device = "${service.address}:${export}";
           fsType = "nfs4";
-          options = "x-systemd.automount,x-systemd.idle-timeout=20,${mountopts}";
+          options = mountopts;
         };
       };
       systemd.tmpfiles.rules = [
@@ -80,7 +83,7 @@ in
       '';
     })
 
-    (mkIf (cfg.nfs_rg_share.enable && service_clients != []) {
+    (mkIf (cfg.roles.nfs_rg_share.enable && service_clients != []) {
       services.nfs.server.enable = true;
       services.nfs.server.exports = ''
         ${export}  ${export_to_clients}
@@ -90,5 +93,30 @@ in
         ${pkgs.nfs-utils}/bin/exportfs -ra
       '';
     })
+
+    (mkIf (boxServer ? address) (
+      let
+        humanUsers =
+          (filterAttrs (n: v: v.isNormalUser && v.group == "users")
+          config.users.users);
+      in
+      {
+        boot.supportedFilesystems = [ "nfs4" ];
+        fileSystems = (listToAttrs
+          (map
+            (user: nameValuePair
+              "${boxMount}/${user}"
+              {
+                device = "${boxServer.address}:/srv/nfs/box/${user}";
+                fsType = "nfs4";
+                options = mountopts;
+              })
+            (attrNames humanUsers)));
+        systemd.tmpfiles.rules =
+          [ "d ${boxMount}" ] ++
+          mapAttrsToList
+            (user: v: "L ${v.home}/box - - - - ${boxMount}/${user}")
+            humanUsers;
+      }))
   ];
 }

--- a/nixos/modules/flyingcircus/static/default.nix
+++ b/nixos/modules/flyingcircus/static/default.nix
@@ -104,6 +104,7 @@ with lib;
     };
 
     ids.gids = {
+      users = 100;
       # The generic 'service' GID is different from Gentoo.
       # But 101 is already used in NixOS.
       service = 900;


### PR DESCRIPTION
Set up systemd automount units for each human user if a NFS box server
exists. Also create links from users' home directories for convenient
access.

This is only the first half (`box` client still missing), but valuable in its own.

Re #21486

@flyingcircusio/release-managers

Impact:

Changelog: Provide NFS box access for NixOS VMs, too.
