### PR TITLE
Ignore ssh error about maximum authentication attempts at journal check

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/check_journal.yaml
+++ b/nixos/modules/flyingcircus/services/sensu/check_journal.yaml
@@ -11,6 +11,7 @@ criticalexceptions:
       - '0 failures 0 errors'
       - 'ACPI Error: Method parse/execution failed'
       - '"timestamp":".*","level":"error"'
+      - 'maximum authentication attempts exceeded for .* port .* ssh2 \[preauth\]'
 
 warningpatterns:
       - '[Ff]ail|FAIL'


### PR DESCRIPTION
Aim of this PR is to don't trigger the sensu journal check in for SSH errors like 

`error: maximum authentication attempts exceeded for root from <someip> port 55373 ssh2 [preauth]`

Re #25476

@flyingcircusio/release-managers