### PR TITLE
23893 libidn cve

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -34,6 +34,8 @@ rec {
 
   innotop = pkgs.callPackage ./percona/innotop.nix { };
 
+  libidn = pkgs.callPackage ./libidn.nix { };
+
   linux = linux_4_4;
   linux_4_4 = pkgs.callPackage ./kernel/linux-4.4.nix {
     kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper ];

--- a/nixos/modules/flyingcircus/packages/libidn.nix
+++ b/nixos/modules/flyingcircus/packages/libidn.nix
@@ -1,0 +1,38 @@
+{ fetchurl, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "libidn-1.33";
+
+  src = fetchurl {
+    url = "mirror://gnu/libidn/${name}.tar.gz";
+    sha256 = "068fjg2arlppjqqpzd714n1lf6gxkpac9v5yyvp1qwmv6nvam9s4";
+  };
+
+  doCheck = ! stdenv.isDarwin;
+
+  meta = {
+    homepage = http://www.gnu.org/software/libidn/;
+    description = "Library for internationalized domain names";
+
+    longDescription = ''
+      GNU Libidn is a fully documented implementation of the
+      Stringprep, Punycode and IDNA specifications.  Libidn's purpose
+      is to encode and decode internationalized domain names.  The
+      native C, C\# and Java libraries are available under the GNU
+      Lesser General Public License version 2.1 or later.
+
+      The library contains a generic Stringprep implementation.
+      Profiles for Nameprep, iSCSI, SASL, XMPP and Kerberos V5 are
+      included.  Punycode and ASCII Compatible Encoding (ACE) via IDNA
+      are supported.  A mechanism to define Top-Level Domain (TLD)
+      specific validation tables, and to compare strings against those
+      tables, is included.  Default tables for some TLDs are also
+      included.
+    '';
+
+    repositories.git = git://git.savannah.gnu.org/libidn.git;
+    license = stdenv.lib.licenses.lgpl2Plus;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "libidn-1.33";
+  name = "libidn-1.32";
 
   src = fetchurl {
     url = "mirror://gnu/libidn/${name}.tar.gz";
-    sha256 = "068fjg2arlppjqqpzd714n1lf6gxkpac9v5yyvp1qwmv6nvam9s4";
+    sha256 = "1xf4hphhahcjm2xwx147lfpsavjwv9l4c2gf6hx71zxywbz5lpds";
   };
 
   doCheck = ! stdenv.isDarwin;


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: None

Changelog: refactored libidn to fit our new package structure

re #23893