### PR TITLE
Restart PostgreSQL automatically after failures

### DIFF
--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -97,6 +97,11 @@ in
     services.postgresql.initialScript = ./postgresql-init.sql;
     services.postgresql.dataDir = "/srv/postgresql/${version}";
 
+    systemd.services.postgresql.serviceConfig = {
+      RestartSec = "92s";
+      Restart = "on-failure";
+    };
+
     environment.systemPackages = [ (builtins.getAttr version package) ];
 
     users.users.postgres = {
@@ -185,10 +190,10 @@ in
       ${local_config}
     '';
 
-    environment.etc."local/postgresql/${version}/README.txt".text = ''
-        Put your local postgresql configuration here. This directory
-        is being included with include_dir.
-        '';
+    environment.etc."local/postgresql/README.txt".text = ''
+      Put your local postgresql configuration into /etc/local/postgresql/${version}/.
+      This directory is being included with 'include_dir'.
+    '';
 
     services.postgresql.authentication = ''
       local postgres root       trust


### PR DESCRIPTION
systemd monitors PostgreSQL's processes anyway. Instruct systemd to
restart the server if it has crashed or failed to come up in the first
place.

I know that this is only a symptomatic fix, but I'm unable to reproduce
the conditions that cause #22431 to happen.

Re #22431

@flyingcircusio/release-managers

Impact:

Changelog: Restart PostgreSQL automatically after crashes.
