### PR TITLE
use mysqlnd driver in PHP

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -86,6 +86,14 @@ rec {
   percona = percona57;
   percona57 = pkgs.callPackage ./percona/5.7.nix { boost = boost159; };
   percona56 = pkgs.callPackage ./percona/5.6.nix { boost = boost159; };
+
+  inherit (pkgs.callPackages ./php { })
+    php54
+    php55
+    php56
+    php70;
+
+
   postfix = pkgs.callPackage ./postfix/3.0.nix { };
   powerdns = pkgs.callPackage ./powerdns.nix { };
 

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -88,11 +88,9 @@ rec {
   percona56 = pkgs.callPackage ./percona/5.6.nix { boost = boost159; };
 
   inherit (pkgs.callPackages ./php { })
-    php54
     php55
     php56
     php70;
-
 
   postfix = pkgs.callPackage ./postfix/3.0.nix { };
   powerdns = pkgs.callPackage ./powerdns.nix { };

--- a/nixos/modules/flyingcircus/packages/php/default.nix
+++ b/nixos/modules/flyingcircus/packages/php/default.nix
@@ -284,11 +284,6 @@ let
 
 in {
 
-  php54 = generic {
-    version = "5.4.45";
-    sha256 = "10k59j7zjx2mrldmgfvjrrcg2cslr2m68azslspcz5acanqjh3af";
-  };
-
   php55 = generic {
     version = "5.5.35";
     sha256 = "1msqh8ii0qwzzcwlwn8f493x2r3hy2djzrrwd5jgs87893b8sr1d";

--- a/nixos/modules/flyingcircus/packages/php/default.nix
+++ b/nixos/modules/flyingcircus/packages/php/default.nix
@@ -1,0 +1,308 @@
+{ lib, stdenv, fetchurl, composableDerivation, autoconf, automake, flex, bison
+, mysql, libxml2, readline, zlib, curl, postgresql, gettext
+, openssl, pkgconfig, sqlite, config, libjpeg, libpng, freetype
+, libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
+, uwimap, pam, gmp, apacheHttpd }:
+
+let
+
+  generic =
+    { version, sha256, url ? "http://www.php.net/distributions/php-${version}.tar.bz2" }:
+
+    let php7 = lib.versionAtLeast version "7.0"; in
+
+    composableDerivation.composableDerivation {} (fixed: {
+
+      inherit version;
+
+      name = "php-${version}";
+
+      enableParallelBuilding = true;
+
+      buildInputs = [ flex bison pkgconfig ];
+
+      flags = {
+
+        # much left to do here...
+
+        # SAPI modules:
+
+        apxs2 = {
+          configureFlags = ["--with-apxs2=${apacheHttpd}/bin/apxs"];
+          buildInputs = [apacheHttpd];
+        };
+
+        # Extensions
+        imap = {
+          configureFlags = [
+            "--with-imap=${uwimap}"
+            "--with-imap-ssl"
+            ];
+          buildInputs = [ uwimap openssl pam ];
+        };
+
+        ldap = {
+          configureFlags = ["--with-ldap=${openldap}"];
+          buildInputs = [openldap cyrus_sasl openssl];
+        };
+
+        mhash = {
+          configureFlags = ["--with-mhash"];
+          buildInputs = [libmhash];
+        };
+
+        curl = {
+          configureFlags = ["--with-curl=${curl}"];
+          buildInputs = [curl openssl];
+        };
+
+        curlWrappers = {
+          configureFlags = ["--with-curlwrappers"];
+        };
+
+        zlib = {
+          configureFlags = ["--with-zlib=${zlib}"];
+          buildInputs = [zlib];
+        };
+
+        libxml2 = {
+          configureFlags = [
+            "--with-libxml-dir=${libxml2}"
+            ];
+          buildInputs = [ libxml2 ];
+        };
+
+        pcntl = {
+          configureFlags = [ "--enable-pcntl" ];
+        };
+
+        readline = {
+          configureFlags = ["--with-readline=${readline}"];
+          buildInputs = [ readline ];
+        };
+
+        sqlite = {
+          configureFlags = ["--with-pdo-sqlite=${sqlite}"];
+          buildInputs = [ sqlite ];
+        };
+
+        postgresql = {
+          configureFlags = ["--with-pgsql=${postgresql}"];
+          buildInputs = [ postgresql ];
+        };
+
+        pdo_pgsql = {
+          configureFlags = ["--with-pdo-pgsql=${postgresql}"];
+          buildInputs = [ postgresql ];
+        };
+
+        mysql = {
+          configureFlags = ["--with-mysql=mysqlnd"];
+          buildInputs = [ mysql.lib ];
+        };
+
+        mysqli = {
+          configureFlags = ["--with-mysqli=mysqlnd"];
+          buildInputs = [ mysql.lib ];
+        };
+
+        # mysqli_embedded = {
+        #   configureFlags = ["--enable-embedded-mysqli"];
+        #   depends = "mysqli";
+        #   assertion = fixed.mysqliSupport;
+        # };
+
+        pdo_mysql = {
+          configureFlags = ["--with-pdo-mysql=${mysql.lib}"];
+          buildInputs = [ mysql.lib ];
+        };
+
+        bcmath = {
+          configureFlags = ["--enable-bcmath"];
+        };
+
+        gd = {
+          # FIXME: Our own gd package doesn't work, see https://bugs.php.net/bug.php?id=60108.
+          configureFlags = [
+            "--with-gd"
+            "--with-freetype-dir=${freetype}"
+            "--with-png-dir=${libpng}"
+            "--with-jpeg-dir=${libjpeg}"
+          ];
+          buildInputs = [ libpng libjpeg freetype ];
+        };
+
+        gmp = {
+          configureFlags = ["--with-gmp=${gmp}"];
+          buildInputs = [ gmp ];
+        };
+
+        soap = {
+          configureFlags = ["--enable-soap"];
+        };
+
+        sockets = {
+          configureFlags = ["--enable-sockets"];
+        };
+
+        openssl = {
+          configureFlags = ["--with-openssl=${openssl}"];
+          buildInputs = [openssl];
+        };
+
+        mbstring = {
+          configureFlags = ["--enable-mbstring"];
+        };
+
+        gettext = {
+          configureFlags = ["--with-gettext=${gettext}"];
+          buildInputs = [gettext];
+        };
+
+        intl = {
+          configureFlags = ["--enable-intl"];
+          buildInputs = [icu];
+        };
+
+        exif = {
+          configureFlags = ["--enable-exif"];
+        };
+
+        xsl = {
+          configureFlags = ["--with-xsl=${libxslt}"];
+          buildInputs = [libxslt];
+        };
+
+        mcrypt = let libmcrypt' = libmcrypt.override { disablePosixThreads = true; }; in {
+          configureFlags = ["--with-mcrypt=${libmcrypt'}"];
+          buildInputs = [libmcrypt'];
+        };
+
+        bz2 = {
+          configureFlags = ["--with-bz2=${bzip2}"];
+          buildInputs = [bzip2];
+        };
+
+        zip = {
+          configureFlags = ["--enable-zip"];
+        };
+
+        ftp = {
+          configureFlags = ["--enable-ftp"];
+        };
+
+        fpm = {
+          configureFlags = ["--enable-fpm"];
+        };
+
+        mssql = stdenv.lib.optionalAttrs (!stdenv.isDarwin) {
+          configureFlags = ["--with-mssql=${freetds}"];
+          buildInputs = [freetds];
+        };
+
+        zts = {
+          configureFlags = ["--enable-maintainer-zts"];
+        };
+
+        calendar = {
+          configureFlags = ["--enable-calendar"];
+        };
+      };
+
+      cfg = {
+        imapSupport = config.php.imap or true;
+        ldapSupport = config.php.ldap or true;
+        mhashSupport = config.php.mhash or true;
+        mysqlSupport = (!php7) && (config.php.mysql or true);
+        mysqliSupport = config.php.mysqli or true;
+        pdo_mysqlSupport = config.php.pdo_mysql or true;
+        libxml2Support = config.php.libxml2 or true;
+        apxs2Support = config.php.apxs2 or true;
+        bcmathSupport = config.php.bcmath or true;
+        socketsSupport = config.php.sockets or true;
+        curlSupport = config.php.curl or true;
+        curlWrappersSupport = (!php7) && (config.php.curlWrappers or true);
+        gettextSupport = config.php.gettext or true;
+        pcntlSupport = config.php.pcntl or true;
+        postgresqlSupport = config.php.postgresql or true;
+        pdo_pgsqlSupport = config.php.pdo_pgsql or true;
+        readlineSupport = config.php.readline or true;
+        sqliteSupport = config.php.sqlite or true;
+        soapSupport = config.php.soap or true;
+        zlibSupport = config.php.zlib or true;
+        opensslSupport = config.php.openssl or true;
+        mbstringSupport = config.php.mbstring or true;
+        gdSupport = config.php.gd or true;
+        intlSupport = config.php.intl or true;
+        exifSupport = config.php.exif or true;
+        xslSupport = config.php.xsl or false;
+        mcryptSupport = config.php.mcrypt or true;
+        bz2Support = config.php.bz2 or false;
+        zipSupport = config.php.zip or true;
+        ftpSupport = config.php.ftp or true;
+        fpmSupport = config.php.fpm or true;
+        gmpSupport = config.php.gmp or true;
+        mssqlSupport = (!php7) && (config.php.mssql or (!stdenv.isDarwin));
+        ztsSupport = config.php.zts or false;
+        calendarSupport = config.php.calendar or true;
+      };
+
+      configurePhase = ''
+        # Don't record the configure flags since this causes unnecessary
+        # runtime dependencies.
+        for i in main/build-defs.h.in scripts/php-config.in; do
+          substituteInPlace $i \
+            --replace '@CONFIGURE_COMMAND@' '(omitted)' \
+            --replace '@CONFIGURE_OPTIONS@' "" \
+            --replace '@PHP_LDFLAGS@' ""
+        done
+
+        iniFile=$out/etc/php-recommended.ini
+        [[ -z "$libxml2" ]] || export PATH=$PATH:$libxml2/bin
+        ./configure --with-config-file-scan-dir=/etc --with-config-file-path=$out/etc --prefix=$out $configureFlags
+      '';
+
+      installPhase = ''
+        unset installPhase; installPhase;
+        cp php.ini-production $iniFile
+      '';
+
+      src = fetchurl {
+        inherit url sha256;
+      };
+
+      meta = with stdenv.lib; {
+        description = "An HTML-embedded scripting language";
+        homepage = http://www.php.net/;
+        license = stdenv.lib.licenses.php301;
+        maintainers = with maintainers; [ globin ];
+      };
+
+      patches = if !php7 then [ ./fix-paths.patch ] else [ ./fix-paths-php7.patch ];
+
+    });
+
+in {
+
+  php54 = generic {
+    version = "5.4.45";
+    sha256 = "10k59j7zjx2mrldmgfvjrrcg2cslr2m68azslspcz5acanqjh3af";
+  };
+
+  php55 = generic {
+    version = "5.5.35";
+    sha256 = "1msqh8ii0qwzzcwlwn8f493x2r3hy2djzrrwd5jgs87893b8sr1d";
+  };
+
+  php56 = generic {
+    version = "5.6.21";
+    sha256 = "144m8xzpqv3pimxh2pjhbk4fy1kch9afkzclcinzv2dnfjspmvdl";
+  };
+
+  php70 = lib.lowPrio (generic {
+    version = "7.0.0beta1";
+    url = "https://downloads.php.net/~ab/php-7.0.0beta1.tar.bz2";
+    sha256 = "1pj3ysfhswg2r370ivp33fv9zbcl3yvhmxgnc731k08hv6hmd984";
+  });
+
+}

--- a/nixos/modules/flyingcircus/packages/php/default.nix
+++ b/nixos/modules/flyingcircus/packages/php/default.nix
@@ -294,10 +294,9 @@ in {
     sha256 = "144m8xzpqv3pimxh2pjhbk4fy1kch9afkzclcinzv2dnfjspmvdl";
   };
 
-  php70 = lib.lowPrio (generic {
-    version = "7.0.0beta1";
-    url = "https://downloads.php.net/~ab/php-7.0.0beta1.tar.bz2";
-    sha256 = "1pj3ysfhswg2r370ivp33fv9zbcl3yvhmxgnc731k08hv6hmd984";
-  });
+  php70 = generic {
+    version = "7.0.15";
+    sha256 = "1nbxwj4yx30k77qibhmnx0rvqhia1zbkwi5ps5nzm0sn6d3zkj58";
+  };
 
 }

--- a/nixos/modules/flyingcircus/packages/php/fix-paths-php7.patch
+++ b/nixos/modules/flyingcircus/packages/php/fix-paths-php7.patch
@@ -1,0 +1,23 @@
+--- php-7.0.0beta1/configure	    2015-07-10 12:11:41.810045613 +0000
++++ php-7.0.0beta1-new/configure	2015-07-17 16:10:21.775528267 +0000
+@@ -6172,7 +6172,7 @@
+     as_fn_error $? "Please note that Apache version >= 2.0.44 is required" "$LINENO" 5
+   fi
+ 
+-  APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
++  APXS_LIBEXECDIR="$prefix/modules"
+   if test -z `$APXS -q SYSCONFDIR`; then
+     INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
+@@ -37303,9 +37303,7 @@
+ 
+ 
+ if test "$PHP_GETTEXT" != "no"; then
+-  for i in $PHP_GETTEXT /usr/local /usr; do
+-    test -r $i/include/libintl.h && GETTEXT_DIR=$i && break
+-  done
++  GETTEXT_DIR=$PHP_GETTEXT
+ 
+   if test -z "$GETTEXT_DIR"; then
+     as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5
+

--- a/nixos/modules/flyingcircus/packages/php/fix-paths.patch
+++ b/nixos/modules/flyingcircus/packages/php/fix-paths.patch
@@ -1,0 +1,68 @@
+diff -ru php-5.4.14/configure php-5.4.14-new/configure
+--- php-5.4.14/configure	2013-04-10 09:53:26.000000000 +0200
++++ php-5.4.14-new/configure	2013-04-22 17:13:55.039043622 +0200
+@@ -6513,7 +6513,7 @@
+ 
+   case $host_alias in
+   *aix*)
+-    APXS_LIBEXECDIR=`$APXS -q LIBEXECDIR`
++    APXS_LIBEXECDIR="$prefix/modules"
+     EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-brtl -Wl,-bI:$APXS_LIBEXECDIR/httpd.exp"
+     PHP_AIX_LDFLAGS="-Wl,-brtl"
+     build_type=shared
+@@ -6706,7 +6706,7 @@
+   if test "$?" != "0"; then
+     APACHE_INSTALL="$APXS -i -a -n php5 $SAPI_SHARED" # Old apxs does not have -S option
+   else
+-    APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
++    APXS_LIBEXECDIR="$prefix/modules"
+     if test -z `$APXS -q SYSCONFDIR`; then
+       APACHE_INSTALL="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                        $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
+@@ -7909,7 +7909,7 @@
+    { (exit 1); exit 1; }; }
+   fi
+ 
+-  APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
++  APXS_LIBEXECDIR="$prefix/modules"
+   if test -z `$APXS -q SYSCONFDIR`; then
+     INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
+@@ -8779,7 +8779,7 @@
+    { (exit 1); exit 1; }; }
+   fi
+ 
+-  APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
++  APXS_LIBEXECDIR="$prefix/modules"
+   if test -z `$APXS -q SYSCONFDIR`; then
+     INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
+@@ -9634,7 +9634,7 @@
+ 
+   case $host_alias in
+   *aix*)
+-    APXS_LIBEXECDIR=`$APXS -q LIBEXECDIR`
++    APXS_LIBEXECDIR="$prefix/modules"
+     EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-brtl -Wl,-bI:$APXS_LIBEXECDIR/httpd.exp"
+     PHP_AIX_LDFLAGS="-Wl,-brtl"
+     build_type=shared
+@@ -9827,7 +9827,7 @@
+   if test "$?" != "0"; then
+     APACHE_HOOKS_INSTALL="$APXS -i -a -n php5 $SAPI_SHARED" # Old apxs does not have -S option
+   else
+-    APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
++    APXS_LIBEXECDIR="$prefix/modules"
+     if test -z `$APXS -q SYSCONFDIR`; then
+       APACHE_HOOKS_INSTALL="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                        $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
+@@ -59657,9 +59657,7 @@
+ 
+ 
+ if test "$PHP_GETTEXT" != "no"; then
+-  for i in $PHP_GETTEXT /usr/local /usr; do
+-    test -r $i/include/libintl.h && GETTEXT_DIR=$i && break
+-  done
++  GETTEXT_DIR=$PHP_GETTEXT
+ 
+   if test -z "$GETTEXT_DIR"; then
+     { { $as_echo "$as_me:$LINENO: error: Cannot locate header file libintl.h" >&5


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: PHP applications will be restarted.

Changelog: PHP: Use MySQL native driver, which supports several functions not available before (see http://php.net/manual/en/mysqlnd.overview.php for details)

