### PR TITLE
22495 import logstash fixed

### DIFF
--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -166,20 +166,27 @@ in
     programs.zsh.enable = true;
 
     environment.pathsToLink = [ "/include" ];
-    environment.shellInit = ''
-     # Grant easy access to the machine's ENC data for some variables to
-     # shell scripts.
-     export FCIO_LOCATION="${cfg.enc.parameters.location or "local"}"
-     export FCIO_ENVIRONMENT="${cfg.enc.parameters.environment or "env"}"
-     export FCIO_HOSTNAME="${cfg.enc.name or "localhost"}"
-
-     # help pip to find libz.so when building lxml
-     export LIBRARY_PATH=/var/run/current-system/sw/lib
-     # help dynamic loading like python-magic to find it's libraries
-     export LD_LIBRARY_PATH=$LIBRARY_PATH
-     # ditto for header files, e.g. sqlite
-     export C_INCLUDE_PATH=/var/run/current-system/sw/include:/var/run/current-system/sw/include/sasl
-    '';
+    environment.shellInit =
+     # FCIO_* only exported if ENC data is present.
+     (lib.optionalString
+      (enc ? name &&
+        (lib.hasAttrByPath [ "parameters" "location" ] enc) &&
+        (lib.hasAttrByPath [ "parameters" "environment" ] enc))
+       ''
+         # Grant easy access to the machine's ENC data for some variables to
+         # shell scripts.
+         export FCIO_LOCATION="${enc.parameters.location}"
+         export FCIO_ENVIRONMENT="${enc.parameters.environment}"
+         export FCIO_HOSTNAME="${enc.name}"
+       '') +
+       ''
+         # help pip to find libz.so when building lxml
+         export LIBRARY_PATH=/var/run/current-system/sw/lib
+         # help dynamic loading like python-magic to fi  nd it's libraries
+         export LD_LIBRARY_PATH=$LIBRARY_PATH
+         # ditto for header files, e.g. sqlite
+         export C_INCLUDE_PATH=/var/run/current-system/sw/include:/var/run/current-system/sw/include/sasl
+       '';
     environment.interactiveShellInit = ''
       TMOUT=43200
     '';

--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -169,9 +169,9 @@ in
     environment.shellInit = ''
      # Grant easy access to the machine's ENC data for some variables to
      # shell scripts.
-     export FCIO_LOCATION="${cfg.enc.parameters.location}"
-     export FCIO_ENVIRONMENT="${cfg.enc.parameters.environment}"
-     export FCIO_HOSTNAME="${cfg.enc.name}"
+     export FCIO_LOCATION="${cfg.enc.parameters.location or "local"}"
+     export FCIO_ENVIRONMENT="${cfg.enc.parameters.environment or "env"}"
+     export FCIO_HOSTNAME="${cfg.enc.name or "localhost"}"
 
      # help pip to find libz.so when building lxml
      export LIBRARY_PATH=/var/run/current-system/sw/lib

--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -167,6 +167,12 @@ in
 
     environment.pathsToLink = [ "/include" ];
     environment.shellInit = ''
+     # Grant easy access to the machine's ENC data for some variables to
+     # shell scripts.
+     export FCIO_LOCATION="${cfg.enc.parameters.location}"
+     export FCIO_ENVIRONMENT="${cfg.enc.parameters.environment}"
+     export FCIO_HOSTNAME="${cfg.enc.name}"
+
      # help pip to find libz.so when building lxml
      export LIBRARY_PATH=/var/run/current-system/sw/lib
      # help dynamic loading like python-magic to find it's libraries

--- a/nixos/modules/flyingcircus/services/graylog.nix
+++ b/nixos/modules/flyingcircus/services/graylog.nix
@@ -20,6 +20,7 @@ let
     message_journal_dir = ${cfg.messageJournalDir}
     mongodb_uri = ${cfg.mongodbUri}
     web_listen_uri = ${cfg.webListenUri}
+    timezone=${config.time.timeZone}
     rest_listen_uri = ${cfg.restListenUri}
 
     ${cfg.extraConfig}


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: - nixos.tests.flyingcircus.elasticsearch is working again

Changelog: - added some default values in platform/default.nix's FCIO* variables. 

re #22495