### PR TITLE
put graylog behind a proxy

### DIFF
--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -6,7 +6,7 @@ let
   cfg = config.flyingcircus.roles.loghost;
   fclib = import ../lib;
 
-  listenOn = head (fclib.listenAddresses config "ethsrv");
+  listenOn = "127.0.0.1";
   serviceUser = "graylog";
 
   loghostService = findFirst
@@ -38,9 +38,9 @@ let
     else cfg.passwordSecret;
 
 
-  port = 9000;
+  port = 9001;
   webListenUri = "http://${listenOn}:${toString port}/tools/${config.flyingcircus.enc.name}/graylog";
-  restListenUri = "http://${listenOn}:${toString port}/tools/${config.flyingcircus.enc.name}/graylog/api";
+  restListenUri = "${webListenUri}/api";
 
   # -- helper functions --
   passwordActivation = file: password: user:
@@ -108,7 +108,34 @@ in
     (mkIf cfg.enable {
 
       # XXX Access should *only* be allowed from directory and same-rg.
-      networking.firewall.allowedTCPPorts = [ port ];
+      networking.firewall.allowedTCPPorts = [ 9000 ];
+
+      flyingcircus.roles.nginx.enable = true;
+      flyingcircus.roles.nginx.httpConfig =
+      let
+          listenOn = lib.concatMapStringsSep "\n    "
+              (addr: "listen ${addr}:9000;")
+              (fclib.listenAddressesQuotedV6 config "ethsrv");
+
+          allow = lib.concatMapStringsSep "\n    "
+              (addr: "allow ${addr};")
+              (config.flyingcircus.static.directory.proxy_ips);
+
+
+      in
+      ''
+        server {
+            ${listenOn}
+
+            ${allow}
+            deny all;
+
+            location /tools/${config.flyingcircus.enc.name}/graylog {
+                proxy_pass http://localhost:9001;
+                root /tools/${config.flyingcircus.enc.name}/graylog ;
+            }
+          }
+      '';
 
       system.activationScripts.fcio-loghost =
         stringAfter
@@ -124,7 +151,7 @@ in
           "${config.networking.hostName}.${config.networking.domain}:9300";
         # ipv6 would be nice too
         extraConfig = ''
-          trusted_proxies 195.62.125.243/32, 195.62.125.11/32, 172.22.49.56/32
+          trusted_proxies 127.0.0.1/8
         '';
       };
 
@@ -171,7 +198,7 @@ in
             auto_create_user = true;
             username_header = "Remote-User";
             require_trusted_proxies = true;
-            trusted_proxies = "95.62.125.11/32, 195.62.125.243/32, 172.22.49.56/32";
+            trusted_proxies = "127.0.0.1/8";
           };
         in
           ''${pkgs.fcmanage}/bin/fc-graylog \

--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -131,7 +131,7 @@ in
             deny all;
 
             location /tools/${config.flyingcircus.enc.name}/graylog {
-                proxy_pass http://localhost:9001;
+                proxy_pass http://127.0.0.1:9001;
                 root /tools/${config.flyingcircus.enc.name}/graylog ;
             }
           }

--- a/nixos/modules/flyingcircus/static/default.nix
+++ b/nixos/modules/flyingcircus/static/default.nix
@@ -74,6 +74,10 @@ with lib;
       standalone = [ "8.8.8.8" "8.8.4.4" ];
     };
 
+    flyingcircus.static.directory = {
+      proxy_ips = ["195.62.125.6" "195.62.125.11" "2a02:248:101:62::108c" "2a02:248:101:62::dd"];
+    };
+
     flyingcircus.static.ntpservers = {
       # Those are the routers and ceph mons. This needs to move to the
       # directory service discovery.


### PR DESCRIPTION
- graylog listens on lo, port 9001
- nginx on srv, port 9000, access allowed only by directory
- added directory proxy ips to static/default.nix

@flyingcircusio/release-managers

re #22495
