### PR TITLE
updated postgres to 9.6

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ pkgs ? (import <nixpkgs> {})}:
 
 rec {
 
@@ -88,6 +88,17 @@ rec {
   percona = percona57;
   percona57 = pkgs.callPackage ./percona/5.7.nix { boost = boost159; };
   percona56 = pkgs.callPackage ./percona/5.6.nix { boost = boost159; };
+
+  inherit (pkgs.callPackages ./postgresql { })
+    postgresql90
+    postgresql91
+    postgresql92
+    postgresql93
+    postgresql94
+    postgresql95
+    postgresql96;
+
+  rum = pkgs.callPackage ./postgresql/rum { postgresql = postgresql96; };
 
   inherit (pkgs.callPackages ./php { })
     php55

--- a/nixos/modules/flyingcircus/packages/postgresql/default.nix
+++ b/nixos/modules/flyingcircus/packages/postgresql/default.nix
@@ -1,0 +1,121 @@
+{ lib, stdenv, glibc, fetchurl, zlib, readline, libossp_uuid, openssl, makeWrapper }:
+
+let
+
+  common = { version, sha256, psqlSchema } @ args:
+   let atLeast = lib.versionAtLeast version; in stdenv.mkDerivation (rec {
+    name = "postgresql-${version}";
+
+    src = fetchurl {
+      url = "mirror://postgresql/source/v${version}/${name}.tar.bz2";
+      inherit sha256;
+    };
+
+    outputs = [ "out" "doc" ];
+
+    buildInputs =
+      [ zlib readline openssl makeWrapper ]
+      ++ lib.optionals (!stdenv.isDarwin) [ libossp_uuid ];
+
+    enableParallelBuilding = true;
+
+    makeFlags = [ "world" ];
+
+    configureFlags = [
+      "--with-openssl"
+      "--sysconfdir=/etc"
+    ]
+      ++ lib.optional (stdenv.isDarwin)  "--with-uuid=e2fs"
+      ++ lib.optional (!stdenv.isDarwin) "--with-ossp-uuid";
+
+    patches =
+      [ (if atLeast "9.4" then ./disable-resolve_symlinks-94.patch else ./disable-resolve_symlinks.patch)
+        (if atLeast "9.6" then ./less-is-more-96.patch             else ./less-is-more.patch)
+        (if atLeast "9.6" then ./hardcode-pgxs-path-96.patch       else ./hardcode-pgxs-path.patch)
+        ./specify_pkglibdir_at_runtime.patch
+      ];
+
+    installTargets = [ "install-world" ];
+
+    LC_ALL = "C";
+
+    postConfigure =
+      let path = if atLeast "9.6" then "src/common/config_info.c" else "src/bin/pg_config/pg_config.c"; in
+        ''
+          # Hardcode the path to pgxs so pg_config returns the path in $out
+          substituteInPlace "${path}" --replace HARDCODED_PGXS_PATH $out/lib
+        '';
+
+    postInstall =
+      ''
+        # Prevent a retained dependency on gcc-wrapper.
+        substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv.cc}/bin/ld ld
+      '';
+
+    postFixup =
+      ''
+        # initdb needs access to "locale" command from glibc.
+        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc}/bin
+      '';
+
+    disallowedReferences = [ stdenv.cc ];
+
+    passthru = {
+      inherit readline psqlSchema;
+    };
+
+    meta = with lib; {
+      homepage = http://www.postgresql.org/;
+      description = "A powerful, open source object-relational database system";
+      license = licenses.postgresql;
+      maintainers = [ maintainers.ocharles ];
+      platforms = platforms.unix;
+      hydraPlatforms = platforms.linux;
+    };
+  });
+
+in {
+
+  postgresql90 = common {
+    version = "9.0.23";
+    psqlSchema = "9.0";
+    sha256 = "1pnpni95r0ry112z6ycrqk5m6iw0vd4npg789czrl4qlr0cvxg1x";
+  };
+
+  postgresql91 = common {
+    version = "9.1.20";
+    psqlSchema = "9.1";
+    sha256 = "0dr9hz1a0ax30f6jvnv2rck0zzxgk9x7nh4n1xgshrf26i1nq7kd";
+  };
+
+  postgresql92 = common {
+    version = "9.2.15";
+    psqlSchema = "9.2";
+    sha256 = "0q1yahkfys78crf59avp02ibd0lp3z7h626xchyfi6cqb03livbw";
+  };
+
+  postgresql93 = common {
+    version = "9.3.11";
+    psqlSchema = "9.3";
+    sha256 = "08ba951nfiy516flaw352shj1zslxg4ryx3w5k0adls1r682l8ix";
+  };
+
+  postgresql94 = common {
+    version = "9.4.6";
+    psqlSchema = "9.4";
+    sha256 = "19j0845i195ksg9pvnk3yc2fr62i7ii2bqgbidfjq556056izknb";
+  };
+
+  postgresql95 = common {
+    version = "9.5.1";
+    psqlSchema = "9.5";
+    sha256 = "1ljvijaja5zy4i5b1450drbj8m3fcm3ly1zzaakp75x30s2rsc3b";
+  };
+
+  postgresql96 = common {
+    version = "9.6.1";
+    psqlSchema = "9.6";
+    sha256 = "1k8zwnabsl8f7vlp3azm4lrklkb9jkaxmihqf0mc27ql9451w475";
+  };
+
+}

--- a/nixos/modules/flyingcircus/packages/postgresql/disable-resolve_symlinks-94.patch
+++ b/nixos/modules/flyingcircus/packages/postgresql/disable-resolve_symlinks-94.patch
@@ -1,0 +1,12 @@
+--- a/src/common/exec.c	2014-09-04 20:19:12.236057588 +0200
++++ b/src/common/exec.c	2014-09-04 20:19:50.550251633 +0200
+@@ -218,6 +218,9 @@
+ static int
+ resolve_symlinks(char *path)
+ {
++	// On NixOS we *want* stuff relative to symlinks.
++	return 0;
++
+ #ifdef HAVE_READLINK
+ 	struct stat buf;
+ 	char		orig_wd[MAXPGPATH],

--- a/nixos/modules/flyingcircus/packages/postgresql/disable-resolve_symlinks.patch
+++ b/nixos/modules/flyingcircus/packages/postgresql/disable-resolve_symlinks.patch
@@ -1,0 +1,14 @@
+diff --git a/src/port/exec.c b/src/port/exec.c
+index c79e8ba..42c4091 100644
+--- a/src/port/exec.c
++++ b/src/port/exec.c
+@@ -216,6 +216,9 @@ find_my_exec(const char *argv0, char *retpath)
+ static int
+ resolve_symlinks(char *path)
+ {
++    // On NixOS we *want* stuff relative to symlinks.
++    return 0;
++
+ #ifdef HAVE_READLINK
+ 	struct stat buf;
+ 	char		orig_wd[MAXPGPATH],

--- a/nixos/modules/flyingcircus/packages/postgresql/hardcode-pgxs-path-96.patch
+++ b/nixos/modules/flyingcircus/packages/postgresql/hardcode-pgxs-path-96.patch
@@ -1,0 +1,14 @@
+diff -Naur postgresql-9.6.1-orig/src/common/config_info.c postgresql-9.6.1/src/common/config_info.c
+--- postgresql-9.6.1-orig/src/common/config_info.c	2016-11-22 21:39:29.231929261 +0100
++++ postgresql-9.6.1/src/common/config_info.c	2016-11-22 23:36:53.685163543 +0100
+@@ -118,7 +118,10 @@
+ 	i++;
+
+ 	configdata[i].name = pstrdup("PGXS");
++	strlcpy(path, "HARDCODED_PGXS_PATH", sizeof(path));
++/* commented out to be able to point to nix $out path
+ 	get_pkglib_path(my_exec_path, path);
++*/
+ 	strlcat(path, "/pgxs/src/makefiles/pgxs.mk", sizeof(path));
+ 	cleanup_path(path);
+ 	configdata[i].setting = pstrdup(path);

--- a/nixos/modules/flyingcircus/packages/postgresql/hardcode-pgxs-path.patch
+++ b/nixos/modules/flyingcircus/packages/postgresql/hardcode-pgxs-path.patch
@@ -1,0 +1,17 @@
+--- a/src/bin/pg_config/pg_config.c
++++ b/src/bin/pg_config/pg_config.c
+@@ -220,11 +220,13 @@ show_sysconfdir(bool all)
+ static void
+ show_pgxs(bool all)
+ {
+-	char		path[MAXPGPATH];
++	char		path[MAXPGPATH] = "HARDCODED_PGXS_PATH";
+ 
+ 	if (all)
+ 		printf("PGXS = ");
++  /* commented out to be able to point to nix $out path
+ 	get_pkglib_path(mypath, path);
++  */
+ 	strlcat(path, "/pgxs/src/makefiles/pgxs.mk", sizeof(path));
+ 	cleanup_path(path);
+ 	printf("%s\n", path);

--- a/nixos/modules/flyingcircus/packages/postgresql/jdbc/default.nix
+++ b/nixos/modules/flyingcircus/packages/postgresql/jdbc/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, ant, jdk }:
+
+let version = "9.3-1100"; in
+
+stdenv.mkDerivation rec {
+  name = "postgresql-jdbc-${version}";
+
+  src = fetchurl {
+    url = "http://jdbc.postgresql.org/download/postgresql-jdbc-${version}.src.tar.gz";
+    sha256 = "0mbdzhzg4ws0i7ps98rg0q5n68lsrdm2klj7y7skaix0rpa57gp6";
+  };
+
+  buildInputs = [ ant jdk ];
+
+  buildPhase = "ant";
+
+  installPhase =
+    ''
+      mkdir -p $out/share/java
+      cp jars/*.jar $out/share/java
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://jdbc.postgresql.org/;
+    description = "JDBC driver for PostgreSQL allowing Java programs to connect to a PostgreSQL database";
+    license = licenses.bsd3;
+  };
+}

--- a/nixos/modules/flyingcircus/packages/postgresql/less-is-more-96.patch
+++ b/nixos/modules/flyingcircus/packages/postgresql/less-is-more-96.patch
@@ -1,0 +1,12 @@
+diff -Naur postgresql-9.6.1-orig/src/include/fe_utils/print.h postgresql-9.6.1/src/include/fe_utils/print.h
+--- postgresql-9.6.1-orig/src/include/fe_utils/print.h	2016-11-22 21:39:29.148932827 +0100
++++ postgresql-9.6.1/src/include/fe_utils/print.h	2016-11-22 21:39:36.283626258 +0100
+@@ -18,7 +18,7 @@
+ 
+ /* This is not a particularly great place for this ... */
+ #ifndef __CYGWIN__
+-#define DEFAULT_PAGER "more"
++#define DEFAULT_PAGER "less"
+ #else
+ #define DEFAULT_PAGER "less"
+ #endif

--- a/nixos/modules/flyingcircus/packages/postgresql/less-is-more.patch
+++ b/nixos/modules/flyingcircus/packages/postgresql/less-is-more.patch
@@ -1,0 +1,12 @@
+diff -Naur postgresql-9.2.7-orig/src/bin/psql/print.h postgresql-9.2.7/src/bin/psql/print.h
+--- postgresql-9.2.7-orig/src/bin/psql/print.h	2014-02-17 14:38:15.000000000 -0500
++++ postgresql-9.2.7/src/bin/psql/print.h	2014-03-04 14:42:28.874014415 -0500
+@@ -178,7 +178,7 @@
+ extern const printTextFormat *get_line_style(const printTableOpt *opt);
+ 
+ #ifndef __CYGWIN__
+-#define DEFAULT_PAGER "more"
++#define DEFAULT_PAGER "less"
+ #else
+ #define DEFAULT_PAGER "less"
+ #endif

--- a/nixos/modules/flyingcircus/packages/postgresql/psqlodbc/default.nix
+++ b/nixos/modules/flyingcircus/packages/postgresql/psqlodbc/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, libiodbc, postgresql, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "psqlodbc-09.01.0200";
+
+  src = fetchurl {
+    url = "http://ftp.postgresql.org/pub/odbc/versions/src/${name}.tar.gz";
+    sha256 = "0b4w1ahfpp34jpscfk2kv9050lh3xl9pvcysqvaigkcd0vsk1hl9";
+  };
+
+  buildInputs = [ libiodbc postgresql openssl ];
+
+  configureFlags = "--with-iodbc=${libiodbc}";
+
+  meta = with stdenv.lib; {
+    homepage = http://psqlodbc.projects.postgresql.org/;
+    description = "ODBC driver for PostgreSQL";
+    license = licenses.lgpl2;
+  };
+}

--- a/nixos/modules/flyingcircus/packages/postgresql/rum/default.nix
+++ b/nixos/modules/flyingcircus/packages/postgresql/rum/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, postgresql }:
+
+let
+  version = "0.1";
+in
+stdenv.mkDerivation {
+  name = "rum-${version}";
+
+  src = fetchFromGitHub {
+    rev = "${version}";
+    owner = "postgrespro";
+    repo = "rum";
+    sha256 = "0qbscy7nl8djnkh4anvywxq47zlamsi5bh08qcnmh4dwkny2931i";
+  };
+
+  buildInputs = [ postgresql ];
+
+  makeFlags = [
+    "USE_PGXS=1"
+  ];
+
+   installPhase =
+   ''
+     mkdir -p $out/{bin,lib}
+     cp ./rum.so $out/lib
+     mkdir -p $out/share/extension
+     cp ./rum.control ./rum--1.0.sql $out/share/extension
+   '';
+ }

--- a/nixos/modules/flyingcircus/packages/postgresql/specify_pkglibdir_at_runtime.patch
+++ b/nixos/modules/flyingcircus/packages/postgresql/specify_pkglibdir_at_runtime.patch
@@ -1,0 +1,29 @@
+diff -ur postgresql-9.5.3-orig/src/port/path.c postgresql-9.5.3/src/port/path.c
+--- postgresql-9.5.3-orig/src/port/path.c	2016-05-09 22:50:23.000000000 +0200
++++ postgresql-9.5.3/src/port/path.c	2016-08-29 22:44:10.507377613 +0200
+@@ -714,7 +714,11 @@
+ void
+ get_lib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*
+@@ -723,7 +727,11 @@
+ void
+ get_pkglib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 {
   config = {
@@ -45,7 +45,6 @@
         openldap
         openssl_1_0_2
         php
-        postgresql
         protobuf
         psmisc
         pv
@@ -66,7 +65,8 @@
         wget
         xfsprogs
         zlib
-    ];
+    ] ++
+    lib.optional (!config.services.postgresql.enable) pkgs.postgresql;
 
   };
 }

--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -14,6 +14,8 @@ let
       then "9.4"
       else if cfg.roles.postgresql95.enable
       then "9.5"
+      else if cfg.roles.postgresql96.enable
+      then "9.6"
       else null;
 
 
@@ -24,6 +26,7 @@ let
     "9.3" = pkgs.postgresql93;
     "9.4" = pkgs.postgresql94;
     "9.5" = pkgs.postgresql95;
+    "9.6" = pkgs.postgresql96;
   };
 
   current_memory = fclib.current_memory config 256;
@@ -86,6 +89,13 @@ in
         description = "Enable the Flying Circus PostgreSQL 9.5 server role.";
       };
     };
+    flyingcircus.roles.postgresql96 = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable the Flying Circus PostgreSQL 9.6 server role.";
+      };
+    };
 
   };
 
@@ -93,11 +103,11 @@ in
 
     services.postgresql.enable = true;
     services.postgresql.package = builtins.getAttr version package;
+    services.postgresql.extraPlugins = lib.optionals (lib.versionAtLeast version "9.6")
+                                       [ (pkgs.rum.override { postgresql = (builtins.getAttr version package); }) ];
 
     services.postgresql.initialScript = ./postgresql-init.sql;
     services.postgresql.dataDir = "/srv/postgresql/${version}";
-
-    environment.systemPackages = [ (builtins.getAttr version package) ];
 
     users.users.postgres = {
       shell = "/run/current-system/sw/bin/bash";
@@ -154,7 +164,7 @@ in
       #------------------------------------------------------------------------------
       wal_level = hot_standby
       wal_buffers = ${toString wal_buffers}MB
-      ${optionalString ((builtins.compareVersions "9.5" version) < 0)
+      ${optionalString (lib.versionOlder version "9.5")
           "checkpoint_segments = 100"
       }
       checkpoint_completion_target = 0.9

--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -99,12 +99,16 @@ in
 
   };
 
-  config = mkIf postgres_enabled {
-
+  config = mkIf postgres_enabled (
+  let
+    postgresqlPkg = builtins.getAttr version package;
+  in
+  {
     services.postgresql.enable = true;
-    services.postgresql.package = builtins.getAttr version package;
-    services.postgresql.extraPlugins = lib.optionals (lib.versionAtLeast version "9.6")
-                                       [ (pkgs.rum.override { postgresql = (builtins.getAttr version package); }) ];
+    services.postgresql.package = postgresqlPkg;
+    services.postgresql.extraPlugins = lib.optionals
+      (lib.versionAtLeast version "9.6")
+      [ (pkgs.rum.override { postgresql = postgresqlPkg; }) ];
 
     services.postgresql.initialScript = ./postgresql-init.sql;
     services.postgresql.dataDir = "/srv/postgresql/${version}";
@@ -213,6 +217,6 @@ in
       };
     };
 
-  };
+  });
 
 }

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -37,6 +37,8 @@
     (import ./postgresql.nix { rolename = "postgresql94"; });
   postgresql_9_5 = hydraJob
     (import ./postgresql.nix { rolename = "postgresql95"; });
+  postgresql_9_6 = hydraJob
+    (import ./postgresql.nix { rolename = "postgresql96"; });
 
   rabbitmq = hydraJob (import ./rabbitmq.nix { inherit system; });
 

--- a/nixos/modules/flyingcircus/tests/postgresql.nix
+++ b/nixos/modules/flyingcircus/tests/postgresql.nix
@@ -2,7 +2,7 @@ import ../../../tests/make-test.nix ({ rolename, lib, pkgs, ... }:
 {
   name = rolename;
   machine =
-    { pkgs, config, ... }:
+    { config, ... }:
     {
       imports = [
         ./setup.nix
@@ -35,7 +35,7 @@ import ../../../tests/make-test.nix ({ rolename, lib, pkgs, ... }:
         psql --echo-all -d employees < ${selectSql} | grep -5 "John Doe"
       '';
 
-      createExtensions = pkgs.writeScript "rim-tests" ''
+      createExtensions = pkgs.writeScript "rum-tests" ''
         psql employees -c "CREATE EXTENSION rum;"
       '';
     in

--- a/nixos/modules/flyingcircus/tests/postgresql.nix
+++ b/nixos/modules/flyingcircus/tests/postgresql.nix
@@ -1,4 +1,4 @@
-import ../../../tests/make-test.nix ({ rolename, pkgs, ... }:
+import ../../../tests/make-test.nix ({ rolename, lib, pkgs, ... }:
 {
   name = rolename;
   machine =
@@ -34,6 +34,10 @@ import ../../../tests/make-test.nix ({ rolename, pkgs, ... }:
         psql --echo-all -d employees < ${insertSql}
         psql --echo-all -d employees < ${selectSql} | grep -5 "John Doe"
       '';
+
+      createExtensions = pkgs.writeScript "rim-tests" ''
+        psql employees -c "CREATE EXTENSION rum;"
+      '';
     in
     ''
       $machine->waitForUnit("postgresql.service");
@@ -43,5 +47,9 @@ import ../../../tests/make-test.nix ({ rolename, pkgs, ... }:
 
       # should not trust connections via TCP
       $machine->fail('psql --no-password -h localhost -l');
+    '' +
+      lib.optionalString  (lib.strings.versionAtLeast rolename "postgresql96")
+    ''# do the rum extension test
+      $machine->succeed('sudo -u postgres -- sh ${createExtensions}');
     '';
 })


### PR DESCRIPTION
- support for the postgresql rum extension
- extended the postgresql test for rum
- only enabled it for postgres >= 9.6
- all-packages.nix is easier to play with: nix-shell -I nixpkgs=. nixos/modules/flyingcircus/packages/all-packages.nix -A <some_pkg>

@flyingcircusio/release-managers

Impact:

Changelog:

re #25926
