### PR TITLE
Fix ES resource limits

### DIFF
--- a/nixos/modules/flyingcircus/roles/elasticsearch.nix
+++ b/nixos/modules/flyingcircus/roles/elasticsearch.nix
@@ -100,7 +100,7 @@ in
       environment = {
         ES_HEAP_SIZE = "${toString esHeap}m";
       };
-      serviceConfig = fclib.mkPlatform {
+      serviceConfig = {
         LimitNOFILE = 65536;
         LimitMEMLOCK = "infinity";
       };


### PR DESCRIPTION
The `mkPlatform` call makes the Limit settings vanish. It appears that, *if* someebody needs the mkPlatform there it must go to each element inside the mapping.

re #26125

@flyingcircusio/release-managers

Impact: ElasticSearch instances will be restarted

Changelog: Fix Elasticsearch resource limits (#26125)