### PR TITLE
Create separate roles for mongodb 3.0 and 3.2

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -54,7 +54,12 @@ rec {
   mariadb = pkgs.callPackage ./mariadb.nix { };
   mailx = pkgs.callPackage ./mailx.nix { };
   memcached = pkgs.callPackage ./memcached.nix { };
-  mongodb = pkgs.callPackage ./mongodb {
+  mongodb = mongodb_3_0;
+  mongodb_3_0 = pkgs.callPackage ../../../../pkgs/servers/nosql/mongodb {
+    pcre = pcre-cpp;
+    sasl = pkgs.cyrus_sasl;
+  };
+  mongodb_3_2 = pkgs.callPackage ./mongodb {
     pcre = pcre-cpp;
     sasl = pkgs.cyrus_sasl;
   };

--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -199,7 +199,7 @@ in
         '';
       };
 
-      flyingcircus.roles.mongodb.enable = true;
+      flyingcircus.roles.mongodb32.enable = true;
       flyingcircus.roles.elasticsearch = {
         enable = true;
         dataDir = "/var/lib/elasticsearch";

--- a/nixos/modules/flyingcircus/tests/mongodb/default.nix
+++ b/nixos/modules/flyingcircus/tests/mongodb/default.nix
@@ -15,7 +15,7 @@ import ../../../../tests/make-test.nix ({ ... }:
         ];
 
         virtualisation.memorySize = 2048;
-        flyingcircus.roles.mongodb.enable = true;
+        flyingcircus.roles.mongodb32.enable = true;
       };
     };
 


### PR DESCRIPTION
I explicitly removed the mongodb role itself. This way rebuild will fail and one can decide which role to choose. There are different branches which provide 3.0 or 3.2.

re #26125

@flyingcircusio/release-managers

Impact:

Changelog: In addition to MongoDB 3.2 we also provide 3.0.
