### PR TITLE
Provide directory selectable mysql version via mysql55/56/57 roles.

### DIFF
--- a/nixos/modules/flyingcircus/roles/mysql.nix
+++ b/nixos/modules/flyingcircus/roles/mysql.nix
@@ -24,18 +24,23 @@ let
     then "!includedir ${/etc/local/mysql}"
     else "";
 
+  package =
+    if config.flyingcircus.roles.mysql55.enable
+    then pkgs.mysql55
+    else if config.flyingcircus.roles.mysql56.enable
+    then pkgs.percona56
+    else if config.flyingcircus.roles.mysql57.enable
+    then pkgs.percona57
+    else null;
+
+  enabled = package != null;
+
 in
 
 {
   options = {
 
     flyingcircus.roles.mysql = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the Flying Circus MySQL server role.";
-      };
 
       rootPassword = mkOption {
         type = types.nullOr types.string;
@@ -57,22 +62,40 @@ in
         '';
       };
 
-      package = mkOption {
-        type = types.package;
-        example = literalExample "pkgs.percona";
-        description = "Which MySQL derivation to use.";
-        default = pkgs.percona;
-      };
-
     };
+
+    flyingcircus.roles.mysql55 = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable the Flying Circus MySQL 5.5 server role.";
+      };
+    };
+
+    flyingcircus.roles.mysql56 = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable the Flying Circus MySQL 5.6 server role.";
+      };
+    };
+
+    flyingcircus.roles.mysql57 = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable the Flying Circus MySQL 5.7 server role.";
+      };
+    };
+
 
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf enabled {
 
     services.percona = {
       enable = true;
-      package = cfg.package;
+      package = package;
       rootPassword = root_password_file;
       dataDir = "/srv/mysql";
       extraOptions = ''
@@ -124,7 +147,7 @@ in
         innodb_write_io_threads         = ${toString (cores * 4)}
         # Percentage. Probably needs local tuning depending on the workload.
         ${lib.optionalString
-          (lib.versionAtLeast cfg.package.mysqlVersion "5.6")
+          (lib.versionAtLeast package.mysqlVersion "5.6")
           "innodb_change_buffer_max_size   = 50"}
         innodb_doublewrite              = 1
         innodb_log_file_size            = 512M

--- a/nixos/modules/flyingcircus/roles/mysql.nix
+++ b/nixos/modules/flyingcircus/roles/mysql.nix
@@ -42,6 +42,16 @@ in
 
     flyingcircus.roles.mysql = {
 
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Safe guard to make sure a specific mysql role is enabled.
+
+          This options must be false.
+        '';
+      };
+
       rootPassword = mkOption {
         type = types.nullOr types.string;
         default = null;
@@ -91,7 +101,7 @@ in
 
   };
 
-  config = mkIf enabled {
+  config = mkIf (assert !cfg.enable; enabled) {
 
     services.percona = {
       enable = true;

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -16,21 +16,10 @@
       inherit system;
     });
 
-   mysql_5_5 = hydraJob
-    (import ./mysql.nix {
-      inherit system;
-      mysql55 = true;
-    });
-  mysql_5_6 = hydraJob
-    (import ./mysql.nix {
-      inherit system;
-      mysql56 = true;
-    });
-  mysql_5_7 = hydraJob
-    (import ./mysql.nix {
-      inherit system;
-      mysql57 = true;
-    });
+  inherit (import ./mysql.nix)
+    mysql_5_5
+    mysql_5_6
+    mysql_5_7;
 
   postgresql_9_3 = hydraJob
     (import ./postgresql.nix { rolename = "postgresql93"; });

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -11,26 +11,25 @@
 
   mongodb = hydraJob (import ./mongodb { inherit system; }) ;
 
-  mysql_5_5 = hydraJob
-    (import ./percona.nix {
-      inherit system;
-      percona = pkgs.mysql55;
-    });
-
   nodejs6 = hydraJob
     (import ./nodejs6.nix {
       inherit system;
     });
 
-  percona_5_7 = hydraJob
-    (import ./percona.nix {
+   mysql_5_5 = hydraJob
+    (import ./mysql.nix {
       inherit system;
-      percona = pkgs.percona56;
+      mysql55 = true;
     });
-  percona_5_6 = hydraJob
-    (import ./percona.nix {
+  mysql_5_6 = hydraJob
+    (import ./mysql.nix {
       inherit system;
-      percona = pkgs.percona57;
+      mysql56 = true;
+    });
+  mysql_5_7 = hydraJob
+    (import ./mysql.nix {
+      inherit system;
+      mysql57 = true;
     });
 
   postgresql_9_3 = hydraJob

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -16,10 +16,8 @@
       inherit system;
     });
 
-  inherit (import ./mysql.nix)
-    mysql_5_5
-    mysql_5_6
-    mysql_5_7;
+  inherit (import ./mysql.nix { inherit system hydraJob; })
+    mysql_5_5 mysql_5_6 mysql_5_7;
 
   postgresql_9_3 = hydraJob
     (import ./postgresql.nix { rolename = "postgresql93"; });

--- a/nixos/modules/flyingcircus/tests/mysql.nix
+++ b/nixos/modules/flyingcircus/tests/mysql.nix
@@ -1,48 +1,49 @@
-import ../../../tests/make-test.nix ({ pkgs
-, lib
-, mysql55 ? false
-, mysql56 ? false
-, mysql57 ? false
-, ... }:
+let
+  mysqlTest = version:
+  import ../../../tests/make-test.nix ({...}:
+  {
+    name = "mysql-${version}";
+
+    nodes = {
+      master =
+        { pkgs, config, ... }:
+        {
+          virtualisation.memorySize = 2048;
+
+          imports = [
+            ./setup.nix
+            ../static/default.nix
+            ../roles/default.nix
+            ../services/default.nix
+            ../platform/default.nix
+          ];
+
+          flyingcircus.roles.${version}.enable = true;
+
+          # Tune those arguments as we'd like to run this on Hydra
+          # in a rather small VM.
+          flyingcircus.roles.mysql.extraConfig = ''
+              [mysqld]
+              innodb-buffer-pool-size         = 10M
+              innodb_log_file_size            = 10M
+          '';
+
+        };
+    };
+
+    testScript = ''
+      startAll;
+
+      $master->waitForUnit("mysql");
+      $master->sleep(1);
+      $master->succeed("mysqladmin ping");
+      $master->succeed("mysql mysql -e 'select * from user' > /dev/null");
+    '';
+  });
+
+in
 {
-  name = "mysql";
-
-  nodes = {
-    master =
-      { pkgs, config, ... }:
-      {
-        virtualisation.memorySize = 2048;
-
-        imports = [
-          ./setup.nix
-          ../static/default.nix
-          ../roles/default.nix
-          ../services/default.nix
-          ../platform/default.nix
-        ];
-
-        flyingcircus.ssl.generate_dhparams = false;
-        flyingcircus.roles.mysql55.enable = mysql55;
-        flyingcircus.roles.mysql56.enable = mysql56;
-        flyingcircus.roles.mysql57.enable = mysql57;
-
-        # Tune those arguments as we'd like to run this on Hydra
-        # in a rather small VM.
-        flyingcircus.roles.mysql.extraConfig = ''
-            [mysqld]
-            innodb-buffer-pool-size         = 10M
-            innodb_log_file_size            = 10M
-        '';
-
-      };
-  };
-
-  testScript = ''
-    startAll;
-
-    $master->waitForUnit("mysql");
-    $master->sleep(1);
-    $master->succeed("mysqladmin ping");
-    $master->succeed("mysql mysql -e 'select * from user' > /dev/null");
-  '';
-})
+  mysql_5_5 = mysqlTest "mysql55";
+  mysql_5_6 = mysqlTest "mysql56";
+  mysql_5_7 = mysqlTest "mysql57";
+}

--- a/nixos/modules/flyingcircus/tests/mysql.nix
+++ b/nixos/modules/flyingcircus/tests/mysql.nix
@@ -1,6 +1,11 @@
-import ../../../tests/make-test.nix ({ pkgs, lib, percona, ... }:
+import ../../../tests/make-test.nix ({ pkgs
+, lib
+, mysql55 ? false
+, mysql56 ? false
+, mysql57 ? false
+, ... }:
 {
-  name = "percona";
+  name = "mysql";
 
   nodes = {
     master =
@@ -17,8 +22,9 @@ import ../../../tests/make-test.nix ({ pkgs, lib, percona, ... }:
         ];
 
         flyingcircus.ssl.generate_dhparams = false;
-        flyingcircus.roles.mysql.enable = true;
-        flyingcircus.roles.mysql.package = percona;
+        flyingcircus.roles.mysql55.enable = mysql55;
+        flyingcircus.roles.mysql56.enable = mysql56;
+        flyingcircus.roles.mysql57.enable = mysql57;
 
         # Tune those arguments as we'd like to run this on Hydra
         # in a rather small VM.

--- a/nixos/modules/flyingcircus/tests/mysql.nix
+++ b/nixos/modules/flyingcircus/tests/mysql.nix
@@ -1,4 +1,7 @@
+{ system, hydraJob }:
 let
+  testFactory = version: (hydraJob (mysqlTest version { inherit system; }));
+
   mysqlTest = version:
   import ../../../tests/make-test.nix ({...}:
   {
@@ -6,29 +9,28 @@ let
 
     nodes = {
       master =
-        { pkgs, config, ... }:
-        {
-          virtualisation.memorySize = 2048;
+      { pkgs, config, ... }:
+      {
+        virtualisation.memorySize = 2048;
 
-          imports = [
-            ./setup.nix
-            ../static/default.nix
-            ../roles/default.nix
-            ../services/default.nix
-            ../platform/default.nix
-          ];
+        imports = [
+          ./setup.nix
+          ../static/default.nix
+          ../roles/default.nix
+          ../services/default.nix
+          ../platform/default.nix
+        ];
 
-          flyingcircus.roles.${version}.enable = true;
+        flyingcircus.roles.${version}.enable = true;
 
-          # Tune those arguments as we'd like to run this on Hydra
-          # in a rather small VM.
-          flyingcircus.roles.mysql.extraConfig = ''
-              [mysqld]
-              innodb-buffer-pool-size         = 10M
-              innodb_log_file_size            = 10M
-          '';
-
-        };
+        # Tune those arguments as we'd like to run this on Hydra
+        # in a rather small VM.
+        flyingcircus.roles.mysql.extraConfig = ''
+          [mysqld]
+          innodb-buffer-pool-size         = 10M
+          innodb_log_file_size            = 10M
+        '';
+      };
     };
 
     testScript = ''
@@ -43,7 +45,7 @@ let
 
 in
 {
-  mysql_5_5 = mysqlTest "mysql55";
-  mysql_5_6 = mysqlTest "mysql56";
-  mysql_5_7 = mysqlTest "mysql57";
+  mysql_5_5 = testFactory "mysql55";
+  mysql_5_6 = testFactory "mysql56";
+  mysql_5_7 = testFactory "mysql57";
 }


### PR DESCRIPTION
The original mysql role is gone. Manual work for every instance running nixos/mysql is required during/after release.

re #26125

@flyingcircusio/release-managers

Impact:

Changelog: Display selected mysql version (mysql55, mysql56, mysql57) in my.flyingcircus.io.
