### PR TITLE
Create a proxy for collectd data which compresses

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
@@ -5,6 +5,21 @@ let
   enc = config.flyingcircus.enc;
   params = if enc ? parameters then enc.parameters else {};
 
+  # If there is no proxy service available, we directly talk to the statshost.
+  proxy_service = lib.findFirst
+    (s: s.service == "statshostproxy-collector")
+    null
+    config.flyingcircus.enc_services;
+
+  # NOTE: We don't use the "service" for statsohst, because it returns the
+  # SRV address. We need FE as we push data in from all over the place.
+  # XXX: Testing-Mode: Fix to stats, but also send to proxy_service (see config
+  # below)
+  graphite_server = "stats.flyingcircus.io";
+    # if proxy_service != null
+    # then proxy_service.address
+    # else "stats.flyingcircus.io";
+
 in
 mkIf (params ? location && params ? resource_group) {
   services.collectd.enable = true;
@@ -44,14 +59,24 @@ mkIf (params ? location && params ? resource_group) {
     </Plugin>
 
     <Plugin "write_graphite">
-     <Node "stats.flyingcircus.io">
-       Host "stats.flyingcircus.io"
-       Port "2003"
-       Prefix "fcio.${params.location}.${params.resource_group}.virtual.generic."
-       Protocol "udp"
-       EscapeCharacter "_"
-       SeparateInstances true
-     </Node>
+      <Node "${graphite_server}">
+        Host "${graphite_server}";
+        Port "2003"
+        Prefix "fcio.${params.location}.${params.resource_group}.virtual.generic."
+        Protocol "udp"
+        EscapeCharacter "_"
+        SeparateInstances true
+      </Node>
+      ${optionalString (proxy_service != null) ''
+        <Node "${proxy_service.address}">
+          Host "${proxy_service.address}";
+          Port "2003"
+          Prefix "fcio.${params.location}.${params.resource_group}.virtual.generic."
+          Protocol "udp"
+          EscapeCharacter "_"
+          SeparateInstances true
+        </Node>
+      ''}
     </Plugin>
   '' +
   concatMapStringsSep "\n"

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -12,6 +12,8 @@ rec {
     lm_sensors = null;  # probably not seen on VMs
     lvm2 = null;        # dito
   };
+  collectdproxy = pkgs.callPackage ./collectdproxy { };
+
   cron = pkgs.callPackage ./cron.nix { };
   curl = pkgs.callPackage ./curl rec {
     fetchurl = pkgs.stdenv.fetchurlBoot;

--- a/nixos/modules/flyingcircus/packages/collectdproxy/README.txt
+++ b/nixos/modules/flyingcircus/packages/collectdproxy/README.txt
@@ -1,0 +1,1 @@
+collectd proxy

--- a/nixos/modules/flyingcircus/packages/collectdproxy/default.nix
+++ b/nixos/modules/flyingcircus/packages/collectdproxy/default.nix
@@ -1,0 +1,23 @@
+{ pkgs
+, python34Packages
+}:
+
+let
+  py = python34Packages;
+
+in
+py.buildPythonPackage rec {
+  name = "collectdproxy-${version}";
+  version = "1.0";
+  namePrefix = "";
+  dontStrip = true;
+  src = ./.;
+
+  buildInputs = [
+    py.pytest
+  ];
+
+  propagatedBuildInputs = [
+  ];
+
+}

--- a/nixos/modules/flyingcircus/packages/collectdproxy/setup.py
+++ b/nixos/modules/flyingcircus/packages/collectdproxy/setup.py
@@ -1,0 +1,63 @@
+from setuptools import setup
+from setuptools.command.test import test as TestCommand
+from codecs import open
+from os import path
+import sys
+
+here = path.abspath(path.dirname(__file__))
+
+with open('README.txt', encoding='ascii') as f:
+    long_description = f.read()
+
+test_req = ['pytest']  # , 'pytest-catchlog', 'freezegun']
+
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
+
+setup(
+    name='collectdproxy',
+    version='0.1',
+    description=__doc__,
+    long_description=long_description,
+    url='https://XXXX',
+    author='Christian Zagrodnick',
+    author_email='cz@flyingcircus.io',
+    license='ZPL',
+    classifiers=[
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+    packages=['collectdproxy'],
+    package_dir={'': 'src'},
+    install_requires=[],
+    tests_require=test_req,
+    cmdclass={'test': PyTest},
+    extras_require={
+        'dev': test_req + ['pytest-cov'],
+        'test': test_req,
+    },
+    zip_safe=False,
+    entry_points={
+        'console_scripts': [
+            'statshost-proxy=collectdproxy.statshost:main',
+            'location-proxy=collectdproxy.location:main',
+        ],
+    },
+)

--- a/nixos/modules/flyingcircus/packages/collectdproxy/src/collectdproxy/location.py
+++ b/nixos/modules/flyingcircus/packages/collectdproxy/src/collectdproxy/location.py
@@ -1,0 +1,108 @@
+import argparse
+import asyncio
+import logging
+import logging.handlers
+import sys
+import zlib
+
+log = logging.getLogger(__name__)
+
+
+queue = []
+
+
+class GraphiteProtocoll:
+
+    def __init__(self):
+        self.known_hosts = set()
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        # Graphite is line based. Split packet into lines. This way we can
+        # estimate the byte size of the queue just by counting.
+        items = data.split(b'\n')
+        queue.extend(items)
+
+        ip = addr[0]
+        if ip not in self.known_hosts:
+            self.known_hosts.add(ip)
+            notice = log.info
+        else:
+            notice = log.debug
+        notice('Received from %s (%d items, %d bytes).',
+               ip, len(items), len(data))
+
+
+@asyncio.coroutine
+def submitter(loop, stats_host):
+    reader, writer = yield from asyncio.open_connection(
+        stats_host, 2004, loop=loop)
+    compressor = zlib.compressobj()
+    loops = 0
+    submits = 0
+    while True:
+        yield from asyncio.sleep(1)
+
+        exc = reader.exception()
+        if exc:
+            raise exc
+
+        loops += 1
+        log.debug('loops=%d queue=%d', loops, len(queue))
+        if not queue or loops % 10 != 0 and len(queue) < 100:
+            continue
+
+        submits += 1
+        # Every 10 seconds or at about 8k data (~80 bytes per queue entry)
+        merged = b'\n'.join(sorted(queue))
+        if submits < 10:
+            notice = log.info
+        elif submits == 10:
+            log.info('Notifying only every 10 submits now.')
+            notice = log.info
+        elif submits % 10 == 0:
+            notice = log.info
+        else:
+            notice = log.debug
+        notice('Sending %d items (%d).', len(queue), submits)
+        queue[:] = []
+        writer.write(compressor.compress(merged))
+        writer.write(compressor.flush(zlib.Z_SYNC_FLUSH))
+        yield from writer.drain()
+
+
+def parse_args():
+    a = argparse.ArgumentParser()
+    a.add_argument('-s', '--stats-host', help='stats host')
+    a.add_argument('-l', '--listen', help='listen host')
+    a.add_argument('-p', '--port', type=int, default=2003, help='listen port')
+    a.add_argument('-d', '--debug', action='store_true', default=False)
+
+    args = a.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(stream=sys.stdout, level=level)
+
+    loop = asyncio.get_event_loop()
+    log.info('Listening for graphite on %s:%d', args.listen, args.port)
+    # One protocol instance will be created to serve all client requests
+    listen = loop.create_datagram_endpoint(
+        GraphiteProtocoll, local_addr=(args.listen, args.port))
+    transport, protocol = loop.run_until_complete(listen)
+
+    loop.run_until_complete(submitter(loop, args.stats_host))
+
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+
+    transport.close()
+    loop.close()

--- a/nixos/modules/flyingcircus/packages/collectdproxy/src/collectdproxy/statshost.py
+++ b/nixos/modules/flyingcircus/packages/collectdproxy/src/collectdproxy/statshost.py
@@ -1,0 +1,111 @@
+import argparse
+import asyncio
+import zlib
+import logging
+import sys
+
+
+log = logging.getLogger(__name__)
+
+MAX_LEN = 1400
+
+
+@asyncio.coroutine
+def handle_receive(reader, writer, sender):
+    peername = writer.get_extra_info('peername')
+    log.info('New connection from {}'.format(peername))
+
+    decompressor = zlib.decompressobj()
+
+    remainder = b''
+    to_submit = []
+    submits = 0
+
+    while True:
+        data = yield from reader.read(MAX_LEN)
+        if not data:
+            break
+        result = decompressor.decompress(data)
+        lines = result.split(b'\n')
+        log.debug('Received %d lines (%d bytes) from %s',
+                  len(lines), len(data), peername)
+        if remainder:
+            to_submit.append(remainder + lines.pop(0))
+        if lines and lines[-1]:
+            remainder = lines.pop()
+        to_submit.extend(lines)
+
+        bts = 0
+        to_send = []
+        while to_submit:
+            if bts + len(to_submit[0]) < MAX_LEN:
+                bts += len(to_submit[0])
+                to_send.append(to_submit.pop(0))
+            else:
+                submits += 1
+
+                send_string = b'\n'.join(to_send + [b''])
+
+                if submits < 10:
+                    notice = log.info
+                elif submits == 10:
+                    log.info('Notifying only every 100 submits now.')
+                    notice = log.info
+                elif submits % 100 == 0:
+                    notice = log.info
+                else:
+                    notice = log.debug
+                notice('Sending %d items, %d bytes (%d).',
+                       len(to_send), len(send_string), submits)
+
+                sender.sendto(send_string)
+                to_send = []
+                bts = 0
+
+        to_submit[:] = []
+
+    log.info('Disconnect from %s', peername)
+
+
+def parse_args():
+    a = argparse.ArgumentParser()
+    a.add_argument('-s', '--stats-host', help='stats host',
+                   default='stats.flyingcircus.io:2003')
+    a.add_argument('-d', '--debug', action='store_true', default=False)
+
+    args = a.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(stream=sys.stdout, level=level)
+
+    log.info('Submitting to %s', args.stats_host)
+    stats_host = tuple(args.stats_host.split(':'))
+
+    loop = asyncio.get_event_loop()
+
+    connect = loop.create_datagram_endpoint(
+        asyncio.DatagramProtocol, remote_addr=stats_host)
+    sender, _ = loop.run_until_complete(connect)
+
+    coro = asyncio.start_server(
+        lambda r, w: handle_receive(r, w, sender),
+        None, 2004)
+    server = loop.run_until_complete(coro)
+
+    # Serve requests until Ctrl+C is pressed
+    log.info('Serving on %s',
+             ', '.join(str(s.getsockname()) for s in server.sockets))
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+
+    # Close the server
+    server.close()
+    loop.run_until_complete(server.wait_closed())
+    loop.close()

--- a/nixos/modules/flyingcircus/services/collectdproxy.nix
+++ b/nixos/modules/flyingcircus/services/collectdproxy.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg_loc = config.services.collectdproxy.location;
+  cfg_stats = config.services.collectdproxy.statshost;
+
+in {
+  options = {
+
+    services.collectdproxy.location = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable proxy in for a location.";
+      };
+
+      statshost = mkOption {
+        type = types.str;
+        description = "name of statshost";
+      };
+
+      listen_addr = mkOption {
+        type = types.str;
+        description = "Bind to";
+      };
+
+    };
+
+    services.collectdproxy.statshost = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable.";
+      };
+      send_to = mkOption {
+        type = types.str;
+        description = "Where to send the uncompressed data to (host:port)";
+      };
+
+    };
+
+  };
+
+  config = mkMerge [
+    (mkIf config.services.collectdproxy.location.enable  {
+      systemd.services.collectdproxy-location = rec {
+        description = "collectd Location proxy";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "network.target" ];
+        after = wants;
+        serviceConfig = {
+          ExecStart = ''
+            ${pkgs.collectdproxy}/bin/location-proxy \
+              -s ${cfg_loc.statshost} \
+              -l ${cfg_loc.listen_addr}
+          '';
+          Restart = "always";
+          RestartSec = "60s";
+          StandardOutput = "journal";
+          StandardError = "journal";
+          User = "nobody";
+          Type = "simple";
+        };
+      };
+    })
+
+   (mkIf config.services.collectdproxy.statshost.enable  {
+      systemd.services.collectdproxy-statshost = rec {
+        description = "collectd Statshost proxy";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "network.target" ];
+        after = wants;
+        serviceConfig = {
+          ExecStart = ''
+            ${pkgs.collectdproxy}/bin/statshost-proxy \
+              -s cfg_stats.send_to
+          '';
+          Restart = "always";
+          RestartSec = "60s";
+          StandardOutput = "journal";
+          StandardError = "journal";
+          User = "nobody";
+          Type = "simple";
+        };
+      };
+    })
+  ];
+}

--- a/nixos/modules/flyingcircus/services/default.nix
+++ b/nixos/modules/flyingcircus/services/default.nix
@@ -3,6 +3,7 @@
 {
   imports =
     [
+     ./collectdproxy.nix
      ./fcmanage.nix
      ./graylog.nix
      ./influxdb011.nix

--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -106,7 +106,7 @@ in {
           chown ${cfg.user} ${cfg.pidFile}
         fi
       '';
-    }; 
+    };
 
     users.extraUsers = optional (cfg.user == "collectd") {
       name = "collectd";


### PR DESCRIPTION
The idea is to aggregate data per location, and to compress it before sending it over the wire. Compressing saves about 9/10 of bandwidth here.

Currently collectd is configured to send to both stats.flyingcircus.io and a local proxy. This wasy we can see how much resources the compression requires before actually putting it into production. Luckly influxdb depulicates the data for the case that we get it twice.

NOTE: This is supposed to do nothing until stathostproxy is available in a location. First I'd like to see how it behaves in DEV.

@flyingcircusio/release-managers

Impact: 

Changelog: none.
