### PR TITLE
Don't report "Disconnecting: Too many authentication failures [preauth]" as a warning inside journal check

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/check_journal.yaml
+++ b/nixos/modules/flyingcircus/services/sensu/check_journal.yaml
@@ -24,6 +24,7 @@ warningexceptions:
       - 'Cannot add dependency job for unit.*quota'
       - '"timestamp":".*","level":"warn"'
       - 'warning: not applying GID change of group'
+      - 'sshd\[.*\]: Disconnecting: Too many authentication failures \[preauth\]'
       - 'sshd\[.*\]: error: Received disconnect'
       - 'proftpd.*crypt\(3\) failed: Invalid argument'
       - 'proftpd.*USER.*\(Login failed\)'


### PR DESCRIPTION
On our platform there is no need to show this warning and therefore it's only noise inside monitoring. 

Re #26285