### PR TITLE
actually start sensu timer.

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/server.nix
+++ b/nixos/modules/flyingcircus/services/sensu/server.nix
@@ -173,6 +173,7 @@ in {
       wantedBy = [ "timers.target" ];
       timerConfig = {
         Unit = "prepare-rabbitmq-for-sensu.service";
+        OnStartupSec = "10m";
         OnUnitActiveSec = "10m";
       };
     };


### PR DESCRIPTION
`OnUnitActiveSec` only becomes effective if the unit was started once. Using `OnStartupSec` to trigger the initial run.

@flyingcircusio/release-managers

Impact: none

Changelog: none
