### PR TITLE
Disable fsck flag for NFS mounts

### DIFF
--- a/nixos/modules/flyingcircus/roles/nfs.nix
+++ b/nixos/modules/flyingcircus/roles/nfs.nix
@@ -71,6 +71,7 @@ in
           device = "${service.address}:${export}";
           fsType = "nfs4";
           options = mountopts;
+          noCheck = true;
         };
       };
       systemd.tmpfiles.rules = [
@@ -108,6 +109,7 @@ in
                 device = "${boxServer.address}:/srv/nfs/box/${user}";
                 fsType = "nfs4";
                 options = mountopts;
+                noCheck = true;
               })
             (attrNames humanUsers)));
         systemd.tmpfiles.rules =


### PR DESCRIPTION
There is no point in fsck'ing NFS mounts and systemd-fstab-generator
is complaining.

Fixes #26163

@flyingcircusio/release-managers

Impact:

Changelog: none
