### PR TITLE
Add sysstat service

### DIFF
--- a/nixos/modules/flyingcircus/services/default.nix
+++ b/nixos/modules/flyingcircus/services/default.nix
@@ -16,5 +16,6 @@
      ./sensu/client.nix
      ./sensu/server.nix
      ./sensu/uchiwa.nix
+     ./sysstat.nix
     ];
 }

--- a/nixos/modules/flyingcircus/services/sysstat.nix
+++ b/nixos/modules/flyingcircus/services/sysstat.nix
@@ -1,0 +1,80 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.sysstat;
+in {
+  options = {
+    services.sysstat = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable sar system activity collection.
+        '';
+      };
+
+      collect-frequency = mkOption {
+        default = "*:00/10";
+        description = ''
+          OnCalendar specification for sysstat-collect
+        '';
+      };
+
+      collect-args = mkOption {
+        default = "1 1";
+        description = ''
+          Arguments to pass sa1 when collecting statistics
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.sysstat = {
+      description = "Resets System Activity Logs";
+      wantedBy = [ "multi-user.target" ];
+      preStart = "test -d /var/log/sa || mkdir -p /var/log/sa";
+
+      serviceConfig = {
+        User = "root";
+        RemainAfterExit = true;
+        Type = "oneshot";
+        ExecStart = "${pkgs.sysstat}/lib/sa/sa1 --boot";
+      };
+    };
+
+    systemd.services.sysstat-collect = {
+      description = "system activity accounting tool";
+      unitConfig.Documentation = "man:sa1(8)";
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        ExecStart = "${pkgs.sysstat}/lib/sa/sa1 ${cfg.collect-args}";
+      };
+    };
+
+    systemd.timers.sysstat-collect = {
+      description = "Run system activity accounting tool on a regular basis";
+      wantedBy = [ "timers.target" ];
+      timerConfig.OnCalendar = cfg.collect-frequency;
+    };
+
+    systemd.services.sysstat-summary = {
+      description = "Generate a daily summary of process accounting";
+      unitConfig.Documentation = "man:sa2(8)";
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        ExecStart = "${pkgs.sysstat}/lib/sa/sa2 -A";
+      };
+    };
+
+    systemd.timers.sysstat-summary = {
+      description = "Generate summary of yesterday's process accounting";
+      wantedBy = [ "timers.target" ];
+      timerConfig.OnCalendar = "00:07:00";
+    };
+  };
+}

--- a/nixos/modules/flyingcircus/services/sysstat.nix
+++ b/nixos/modules/flyingcircus/services/sysstat.nix
@@ -7,21 +7,14 @@ in {
     services.sysstat = {
       enable = mkOption {
         type = types.bool;
-        default = false;
+        default = true;
         description = ''
           Whether to enable sar system activity collection.
         '';
       };
 
-      collect-frequency = mkOption {
-        default = "*:00/10";
-        description = ''
-          OnCalendar specification for sysstat-collect
-        '';
-      };
-
       collect-args = mkOption {
-        default = "1 1";
+        default = "15 240";
         description = ''
           Arguments to pass sa1 when collecting statistics
         '';
@@ -57,11 +50,15 @@ in {
     systemd.timers.sysstat-collect = {
       description = "Run system activity accounting tool on a regular basis";
       wantedBy = [ "timers.target" ];
-      timerConfig.OnCalendar = cfg.collect-frequency;
+      timerConfig = {
+        OnStartupSec = "10s";
+        OnUnitActiveSec = "1h";
+      };
     };
 
     systemd.services.sysstat-summary = {
       description = "Generate a daily summary of process accounting";
+      after = [ "sysstat.service" ];
       unitConfig.Documentation = "man:sa2(8)";
 
       serviceConfig = {
@@ -74,7 +71,7 @@ in {
     systemd.timers.sysstat-summary = {
       description = "Generate summary of yesterday's process accounting";
       wantedBy = [ "timers.target" ];
-      timerConfig.OnCalendar = "00:07:00";
+      timerConfig.OnCalendar = "00:00:00";
     };
   };
 }


### PR DESCRIPTION
re #26608

Add a sysstat service (from upstream) to be enabled if required. Further needs and discussions in #26671. This should be merged so we can manually enable the service when required.

@flyingcircusio/release-managers

Impact:

Changelog: Add sysstat service to be enabled on request.

