### PR TITLE
exclude autofs for datadog checks.

### DIFF
--- a/nixos/modules/services/monitoring/dd-agent.nix
+++ b/nixos/modules/services/monitoring/dd-agent.nix
@@ -60,6 +60,8 @@ let
 
     instances:
       - use_mount: no
+        excluded_filesystems:
+          - autofs
   '';
 
   networkConfig = pkgs.writeText "network.yaml" ''


### PR DESCRIPTION
This would mount the volumes and is completely unnecessary.

Note: the dd-agent service is customized already. I’m continuing that. We probably want to move the service to our part though.

@flyingcircusio/release-managers

Impact:

Changelog: Exclude autofs from datadog's filesystem checks.
