### PR TITLE
Delay PostgreSQL/Redis startup until DAD is complete

### DIFF
--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -59,12 +59,14 @@ in
       chmod 0660 /etc/local/redis/password
     '';
 
-    systemd.services.redis = {
+    systemd.services.redis = rec {
       serviceConfig = {
         LimitNOFILE = 64000;
         PermissionsStartOnly = true;
       };
 
+      after = [ "network.target" "network-interfaces.target" ];
+      wants = after;
       preStart = "echo never > /sys/kernel/mm/transparent_hugepage/enabled";
       postStop = "echo madvise > /sys/kernel/mm/transparent_hugepage/enabled";
     };

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -142,6 +142,7 @@ in
                     # (Flushing this interface may have removed it.)
                     ${config.systemd.package}/bin/systemctl try-restart --no-block network-setup.service
                   fi
+                  sleep 3  # wait for IPv6 DAD
                   ${config.systemd.package}/bin/systemctl start ip-up.target
                 '';
             preStop =


### PR DESCRIPTION
Impact: - 

Changelog: Fix network bug which caused PostgreSQL/Redis failures during VM startup.

Re #22431

@flyingcircusio/release-managers