### PR TITLE
Unblacklist the i6300esb module to allow the watchdog to work.

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
@@ -40,8 +40,13 @@ in
         echo "Want to activate nix.readOnlyStore=false" > /reboot || true
     '';
 
-  boot.blacklistedKernelModules = [ "bochs_drm" ];
+
+   # The upstream ubuntu.conf disables _all_ watchdogs. That's insane.
   boot.kernelModules = [ "i6300esb" ];
+  environment.etc."modprobe.d/ubuntu.conf".source = lib.mkForce ./modprobe.conf;
+
+
+  boot.blacklistedKernelModules = [ "bochs_drm" ];
   boot.initrd.supportedFilesystems = [ "xfs" ];
   boot.kernelParams = [
     # Crash management

--- a/nixos/modules/flyingcircus/infrastructure/fcio/modprobe.conf
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/modprobe.conf
@@ -1,0 +1,224 @@
+## file: blacklist-ath_pci.conf
+
+
+# For some Atheros 5K RF MACs, the madwifi driver loads buts fails to
+# correctly initialize the hardware, leaving it in a state from
+# which ath5k cannot recover. To prevent this condition, stop
+# madwifi from loading by default. Use Jockey to select one driver
+# or the other. (Ubuntu: #315056, #323830)
+blacklist ath_pci
+
+
+
+## file: blacklist-firewire.conf
+
+
+# Select the legacy firewire stack over the new CONFIG_FIREWIRE one.
+
+blacklist ohci1394
+blacklist sbp2
+blacklist dv1394
+blacklist raw1394
+blacklist video1394
+
+#blacklist firewire-ohci
+#blacklist firewire-sbp2
+
+
+## file: blacklist-framebuffer.conf
+
+
+# Framebuffer drivers are generally buggy and poorly-supported, and cause
+# suspend failures, kernel panics and general mayhem.  For this reason we
+# never load them automatically.
+blacklist aty128fb
+blacklist atyfb
+blacklist radeonfb
+blacklist cirrusfb
+blacklist cyber2000fb
+blacklist cyblafb
+blacklist gx1fb
+blacklist hgafb
+blacklist i810fb
+blacklist intelfb
+blacklist kyrofb
+blacklist lxfb
+blacklist matroxfb_base
+blacklist neofb
+blacklist nvidiafb
+blacklist pm2fb
+blacklist rivafb
+blacklist s1d13xxxfb
+blacklist savagefb
+blacklist sisfb
+blacklist sstfb
+blacklist tdfxfb
+blacklist tridentfb
+#blacklist vesafb
+blacklist vfb
+blacklist viafb
+blacklist vt8623fb
+blacklist udlfb
+
+
+## file: blacklist-rare-network.conf
+
+
+# Many less commonly used network protocols have recently had various
+# security flaws discovered. In an effort to reduce the scope of future
+# vulnerability exploitations, they are being blacklisted here so that
+# unprivileged users cannot use them by default. System owners can still
+# either modify this file, or specifically modprobe any needed protocols.
+
+# ax25
+alias net-pf-3 off
+# netrom
+alias net-pf-6 off
+# x25
+alias net-pf-9 off
+# rose
+alias net-pf-11 off
+# decnet
+alias net-pf-12 off
+# econet
+alias net-pf-19 off
+# rds
+alias net-pf-21 off
+# af_802154
+alias net-pf-36 off
+
+
+## file: blacklist-watchdog.conf
+
+
+# Watchdog drivers should not be loaded automatically, but only if a
+# watchdog daemon is installed.
+blacklist acquirewdt
+blacklist advantechwdt
+blacklist alim1535_wdt
+blacklist alim7101_wdt
+blacklist booke_wdt
+blacklist cpu5wdt
+blacklist eurotechwdt
+# FCIO: remove the virtual watchdog from blacklist. Unfortunately nixos uses
+# this in a way that can't be overriden.
+# blacklist i6300esb
+blacklist i8xx_tco
+blacklist ib700wdt
+blacklist ibmasr
+blacklist indydog
+blacklist iTCO_wdt
+blacklist it8712f_wdt
+blacklist it87_wdt
+blacklist ixp2000_wdt
+blacklist ixp4xx_wdt
+blacklist machzwd
+blacklist mixcomwd
+blacklist mpc8xx_wdt
+blacklist mpcore_wdt
+blacklist mv64x60_wdt
+blacklist pc87413_wdt
+blacklist pcwd
+blacklist pcwd_pci
+blacklist pcwd_usb
+blacklist s3c2410_wdt
+blacklist sa1100_wdt
+blacklist sbc60xxwdt
+blacklist sbc7240_wdt
+blacklist sb8360
+blacklist sc1200wdt
+blacklist sc520_wdt
+blacklist sch311_wdt
+blacklist scx200_wdt
+blacklist shwdt
+blacklist smsc37b787_wdt
+blacklist softdog
+blacklist twl4030_wdt
+blacklist w83627hf_wdt
+blacklist w83697hf_wdt
+blacklist w83697ug_wdt
+blacklist w83877f_wdt
+blacklist w83977f_wdt
+blacklist wafer5823wdt
+blacklist wdt
+blacklist wdt_pci
+blacklist wm8350_wdt
+
+
+## file: blacklist.conf
+
+
+# This file lists those modules which we don't want to be loaded by
+# alias expansion, usually so some other driver will be loaded for the
+# device instead.
+
+# evbug is a debug tool that should be loaded explicitly
+blacklist evbug
+
+# these drivers are very simple, the HID drivers are usually preferred
+blacklist usbmouse
+blacklist usbkbd
+
+# replaced by e100
+blacklist eepro100
+
+# replaced by tulip
+blacklist de4x5
+
+# causes no end of confusion by creating unexpected network interfaces
+blacklist eth1394
+
+# snd_intel8x0m can interfere with snd_intel8x0, doesn't seem to support much
+# hardware on its own (Ubuntu bug #2011, #6810)
+blacklist snd_intel8x0m
+
+# Conflicts with dvb driver (which is better for handling this device)
+blacklist snd_aw2
+
+# causes failure to suspend on HP compaq nc6000 (Ubuntu: #10306)
+blacklist i2c_i801
+
+# replaced by p54pci
+blacklist prism54
+
+# replaced by b43 and ssb.
+blacklist bcm43xx
+
+# most apps now use garmin usb driver directly (Ubuntu: #114565)
+blacklist garmin_gps
+
+# replaced by asus-laptop (Ubuntu: #184721)
+blacklist asus_acpi
+
+# low-quality, just noise when being used for sound playback, causes
+# hangs at desktop session start (Ubuntu: #246969)
+blacklist snd_pcsp
+
+# ugly and loud noise, getting on everyone's nerves; this should be done by a
+# nice pulseaudio bing (Ubuntu: #77010)
+blacklist pcspkr
+
+# EDAC driver for amd76x clashes with the agp driver preventing the aperture
+# from being initialised (Ubuntu: #297750). Blacklist so that the driver
+# continues to build and is installable for the few cases where its
+# really needed.
+blacklist amd76x_edac
+
+
+## file: iwlwifi.conf
+
+
+# /etc/modprobe.d/iwlwifi.conf
+# iwlwifi will dyamically load either iwldvm or iwlmvm depending on the
+# microcode file installed on the system.  When removing iwlwifi, first
+# remove the iwl?vm module and then iwlwifi.
+remove iwlwifi \
+(/run/booted-system/sw/bin/lsmod | /nix/store/d96rkzqrrpdkn6pkadchx0hmkqm0xw87-gnugrep-2.21/bin/grep -o -e ^iwlmvm -e ^iwldvm -e ^iwlwifi | /nix/store/zv64rbh86rz6iq729i61w9cy0g681qb9-findutils-4.4.2/bin/xargs /run/booted-system/sw/bin/rmmod) \
+&& /run/booted-system/sw/bin/modprobe -r mac80211
+
+
+## file: mlx4.conf
+
+
+# mlx4_core gets automatically loaded, load mlx4_en also (LP: #1115710)
+softdep mlx4_core post: mlx4_en


### PR DESCRIPTION
We can't prove that this does anything useful, but we bashed our heads for
about 30 minutes trying to provoke a watchdog reboot. Unfortunately, the
kexec mechanism that is in place usually catches all issues we can provoke
faster than the watchdog. In general this is good news because that means
we have multiple safety nets. In practice we can only show that the module
now loads and that systemd is picking it up.

Fixes #23942

@flyingcircusio/release-managers

Impact:

Changelog:
