### PR TITLE
The sensu client now has a configurable loglevel so we can customize it

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -105,6 +105,13 @@ in {
           The address of the server (RabbitMQ) to connect to.
         '';
       };
+      loglevel = mkOption {
+        type = types.str;
+        default = "warn";
+        description = ''
+          The level of logging.
+        '';
+      };
       password = mkOption {
         type = types.str;
         description = ''
@@ -236,7 +243,7 @@ in {
       serviceConfig = {
         User = "sensuclient";
         ExecStart = ''
-          ${sensu}/bin/sensu-client -L warn -c ${client_json} ${local_sensu_configuration}
+          ${sensu}/bin/sensu-client -L ${cfg.loglevel} -c ${client_json} ${local_sensu_configuration}
         '';
         Restart = "always";
         RestartSec = "5s";


### PR DESCRIPTION

@flyingcircusio/release-managers

Impact:

Restarts sensu client

Changelog:

The sensu client now has a configurable loglevel so we can customize it locally to aid debugging.
