### PR TITLE
Allow to add ES nodes to the graylog cluster.

### DIFF
--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -100,6 +100,14 @@ let
 
   syslogPort = 5140;
 
+  esNodes =
+    ["${config.networking.hostName}.${config.networking.domain}:9350"] ++
+    map
+      (service: "${service.address}:9300")
+      (filter
+        (s: s.service == "elasticsearch-node")
+        config.flyingcircus.enc_services);
+
 in
 {
 
@@ -190,7 +198,7 @@ in
         elasticsearchClusterName = "graylog";
         inherit passwordSecret rootPasswordSha2 webListenUri restListenUri;
         elasticsearchDiscoveryZenPingUnicastHosts =
-          "${config.networking.hostName}.${config.networking.domain}:9300";
+          concatStringsSep "," esNodes;
         javaHeap = ''${toString
           (fclib.max [
             ((fclib.current_memory config 1024) / 5)
@@ -215,7 +223,7 @@ in
         dataDir = "/var/lib/elasticsearch";
         clusterName = "graylog";
         heapDivisor = 3;
-        esNodes = ["${config.networking.hostName}.${config.networking.domain}:9350"];
+        esNodes = esNodes;
       };
 
       systemd.services.graylog-config = {

--- a/nixos/modules/flyingcircus/services/graylog.nix
+++ b/nixos/modules/flyingcircus/services/graylog.nix
@@ -17,6 +17,7 @@ let
     elasticsearch_cluster_name = ${cfg.elasticsearchClusterName}
     elasticsearch_discovery_zen_ping_multicast_enabled = ${configBool cfg.elasticsearchDiscoveryZenPingMulticastEnabled}
     elasticsearch_discovery_zen_ping_unicast_hosts = ${cfg.elasticsearchDiscoveryZenPingUnicastHosts}
+    elasticsearch_network_host = ${config.networking.hostName}.${config.networking.domain}
     message_journal_dir = ${cfg.messageJournalDir}
     mongodb_uri = ${cfg.mongodbUri}
     web_listen_uri = ${cfg.webListenUri}


### PR DESCRIPTION
To do so you

* add the ES role to the loghost VM
* set the cluster name to “graylog” on any other ES VM in the RG.

re #26893

@flyingcircusio/release-managers

Impact: Graylog and ElasticSearch instances will be restarted, if there is a Graylog in the project.

Changelog: Allow to add ElasticSearch nodes to the graylog cluster.