### PR TITLE
26455 update nodejs4

### DIFF
--- a/nixos/modules/flyingcircus/packages/nodejs/default.nix
+++ b/nixos/modules/flyingcircus/packages/nodejs/default.nix
@@ -56,10 +56,10 @@ let
 
 in {
   nodejs4 = common rec {
-    version = "4.8.2";
+    version = "4.8.3";
     src = fetchurl {
       url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
-      sha256 = "b961350b8490c791bdd3663925662ba0fbe01e004b43f1c2779baffcc816b930";
+      sha256 = "d84e7544c2e31a2d0825b4f8b093d169bf8bdb1881ee8cf75ff937918e59e9cb";
     };
   };
 

--- a/nixos/modules/flyingcircus/packages/nodejs/default.nix
+++ b/nixos/modules/flyingcircus/packages/nodejs/default.nix
@@ -56,10 +56,10 @@ let
 
 in {
   nodejs4 = common rec {
-    version = "4.6.0";
+    version = "4.8.2";
     src = fetchurl {
       url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
-      sha256 = "1566q1kkv8j30fgqx8sm2h8323f38wwpa1hfb10gr6z46jyhv4a2";
+      sha256 = "b961350b8490c791bdd3663925662ba0fbe01e004b43f1c2779baffcc816b930";
     };
   };
 

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -11,6 +11,11 @@
 
   mongodb = hydraJob (import ./mongodb { inherit system; }) ;
 
+  nodejs4 = hydraJob
+    (import ./nodejs4.nix {
+      inherit system;
+    });
+
   nodejs6 = hydraJob
     (import ./nodejs6.nix {
       inherit system;

--- a/nixos/modules/flyingcircus/tests/nodejs4.nix
+++ b/nixos/modules/flyingcircus/tests/nodejs4.nix
@@ -1,0 +1,30 @@
+import ../../../tests/make-test.nix ({ ... }:
+{
+  name = "nodejs4";
+
+  nodes = {
+    master =
+      { pkgs, config, ... }:
+      {
+
+        imports = [
+          ./setup.nix
+          ../static/default.nix
+          ../roles/default.nix
+          ../services/default.nix
+          ../platform/default.nix
+        ];
+
+        virtualisation.memorySize = 1024;
+        environment.systemPackages = [
+          pkgs.nodejs4
+        ];
+      };
+  };
+
+  testScript = ''
+    startAll;
+
+    $master->succeed('node -e \'console.log("ok")\' ');
+  '';
+})


### PR DESCRIPTION
This PR updates NodeJS4 to latest maintenance release inside: 4.8.3. It also adds a simple test for NodeJS service. 

@flyingcircusio/release-managers

Impact:

Changelog:
Update NodeJS4 to 4.8.3
