### PR TITLE
Don't show passwords inside openvpn check output in sensu

### DIFF
--- a/nixos/modules/flyingcircus/roles/external_net/openvpn.nix
+++ b/nixos/modules/flyingcircus/roles/external_net/openvpn.nix
@@ -84,7 +84,14 @@ let
   mgmPsk = builtins.hashString "md5" ("OpenVPN@" + config.networking.hostName);
 
   checkOpenVPN = pkgs.writeScript "check_openvpn" ''
-    #!${pkgs.expect}/bin/expect -f
+    #!${pkgs.bash}/bin/bash
+    OUTPUT="$(${pkgs.expect}/bin/expect -f ${checkOpenVPNExpect})"
+    EXITCODE=$?
+    echo "$OUTPUT" | egrep -v "PASSWORD"
+    exit $EXITCODE
+  '';
+
+  checkOpenVPNExpect = pkgs.writeText "check_openvpn_expect" ''
     set timeout 20
 
     puts "OpenVPN: checking management interface"


### PR DESCRIPTION
This PR prevents passwords from being printed into output of sensu check when checking whether openvpn is working. 

Re #26899

@flyingcircusio/release-managers

