### PR TITLE
Update PostgreSQL 9.5.1 -> 9.5.7

### DIFF
--- a/nixos/modules/flyingcircus/packages/postgresql/default.nix
+++ b/nixos/modules/flyingcircus/packages/postgresql/default.nix
@@ -107,9 +107,9 @@ in {
   };
 
   postgresql95 = common {
-    version = "9.5.1";
+    version = "9.5.7";
     psqlSchema = "9.5";
-    sha256 = "1ljvijaja5zy4i5b1450drbj8m3fcm3ly1zzaakp75x30s2rsc3b";
+    sha256 = "8b1e936f82109325decc0f5575e846b93fb4fd384e8c4bde83ff5e7f87fc6cad";
   };
 
   postgresql96 = common {


### PR DESCRIPTION
This PR updates PostgreSQL from 9.5.1 to 9.5.7 

Re #27035

@flyingcircusio/release-managers

Impact:
* Postgres 9.5 servers needs to be restarted
* Some indexes might needs to be recalculated. See
   *  https://www.postgresql.org/docs/9.5/static/release-9-5-2.html
    * https://www.postgresql.org/docs/9.5/static/release-9-5-6.html

