### PR TITLE
Update Postgres 9.4.6 -> 9.4.12

### DIFF
--- a/nixos/modules/flyingcircus/packages/postgresql/default.nix
+++ b/nixos/modules/flyingcircus/packages/postgresql/default.nix
@@ -101,9 +101,9 @@ in {
   };
 
   postgresql94 = common {
-    version = "9.4.6";
+    version = "9.4.12";
     psqlSchema = "9.4";
-    sha256 = "19j0845i195ksg9pvnk3yc2fr62i7ii2bqgbidfjq556056izknb";
+    sha256 = "fca055481875d1c49e31c28443f56472a1474b3fbe25b7ae64440c6118f82e64";
   };
 
   postgresql95 = common {


### PR DESCRIPTION
This PR will update PostgreSQL 9.4.x to 9.4.12. 

@flyingcircusio/release-managers

Impact:
* Postgres server needs to be restarted
* Some indexes might needs to be recalculated

Changelog: