### PR TITLE
dnsmasq: discern authoritative and resolver roles

### DIFF
--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -70,10 +70,10 @@ in
     flyingcircus.network.policyRouting = {
       enable = lib.mkOption {
         type = lib.types.bool;
-        default = !(pathExists "/etc/local/simplerouting");
+        default = true;
         description = ''
-          Enable policy routing? Touch /etc/local/simplerouting to turn policy
-          routing off.
+          Enable policy routing? Automatically deselected for external network
+          gateways.
         '';
       };
 


### PR DESCRIPTION
We have seen DNS amplification attacks because dnsmasq on external
network gateways used to respond to recursive queries on FE. dnsmasq has
been opened on FE originally to server DNS queries coming from OpenVPN
clients.

Now functionality has been separated: dnsmasq acts as recursive resolver
on nx0 and tap0 (or whatever OpenVPN likes to name its local interface),
but acts as authoritative nameserver on the FE address (declines
recursive queries).

To achieve this, we create a new NixOS config option `frontendName`
which points to the FQDN of the public FE interface. dnsmasq is
configured in authoritative mode on this interfaces while declining
recursive DNS and DHCP queries generally on ethfe and ethsto. A Python
snippet wrapped in a derivation performs the necessary address
computations.

Note that the local feature switch `/etc/local/simplerouting` is now
gone since I did not find any machine that used it. This does not affect
the fact that simple (=non-policy) routing gets activated on external
network gateways automatically as before.

Re #27339

@flyingcircusio/release-managers

Impact:

Changelog: Separate resolver and authoritative nameserver functionalities of dnsmasq on external network gateways to prevent DNS amplification attacks (#27339).
