### PR TITLE
make elasticsearch heap setting a percenatage of system memory instea…

### DIFF
--- a/nixos/modules/flyingcircus/roles/elasticsearch.nix
+++ b/nixos/modules/flyingcircus/roles/elasticsearch.nix
@@ -33,7 +33,7 @@ let
 
   esHeap =
     fclib.min [
-      (currentMemory / cfg.heapDivisor)
+      (currentMemory * cfg.heapPercentage / 100)
       (31 * 1024)];
 
 in
@@ -64,12 +64,12 @@ in
         '';
       };
 
-      heapDivisor = mkOption {
+      heapPercentage = mkOption {
         type = types.int;
-        default = 2;
+        default = 50;
         description = ''
           Tweak amount of memory to use for ES heap
-          (systemMemory / heapDivisor)
+          (systemMemory * heapPercentage / 100)
         '';
       };
 

--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -202,7 +202,7 @@ in
           concatStringsSep "," esNodes;
         javaHeap = ''${toString
           (fclib.max [
-            ((fclib.current_memory config 1024) / 5)
+            ((fclib.current_memory config 1024) * 15 / 100)
             1024
             ])}m'';
         extraConfig = ''
@@ -223,7 +223,7 @@ in
         enable = true;
         dataDir = "/var/lib/elasticsearch";
         clusterName = "graylog";
-        heapDivisor = 3;
+        heapPercentage = 35;
         esNodes = esNodes;
       };
 


### PR DESCRIPTION
…d of a fraction.

The problem with fraction is, that there are no floats, hence it’s not tunable enough.

@flyingcircusio/release-managers

Impact: 
* Graylog instances will be restarted.
* ElasticSearch nodes on a Loghost VM will be restarted.

Changelog: Tweak Graylog and ElasticSearch Java-Heap settings.
