### PR TITLE
add a size check for the system.journal log file

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcsensuplugins/fc/sensuplugins/journalfile.py
+++ b/nixos/modules/flyingcircus/packages/fcsensuplugins/fc/sensuplugins/journalfile.py
@@ -1,0 +1,59 @@
+"""Check the size of the journal file.
+
+Files which are smaller than 500 bytes are considered to be defect.
+"""
+
+from glob import glob
+
+import argparse
+import logging
+import nagiosplugin
+import os.path
+
+_log = logging.getLogger('nagiosplugin')
+
+
+class JournalFile(nagiosplugin.Resource):
+
+    def __init__(self):
+        self.journal_file = glob('/var/log/journal/*/system.journal')[0]
+        if not self.journal_file:
+            return True
+
+    def probe(self):
+        size = os.path.getsize(self.journal_file)
+        return nagiosplugin.Metric(
+            self.journal_file, size, 'B', min=0, context='critical')
+
+
+class JournalFileSummary(nagiosplugin.Summary):
+
+    def ok(self, results):
+        msg = []
+        for r in results:
+            msg.append('{}: {}'.format(r.metric.name, r.metric.value))
+        return ', '.join(msg)
+
+    def problem(self, results):
+        msg = []
+        for r in results.most_significant:
+            msg.append('{}: {}'.format(r.metric.name, r.metric.valueunit))
+        return ', '.join(msg)
+
+
+@nagiosplugin.guarded
+def main():
+    a = argparse.ArgumentParser()
+    a.add_argument('-c', '--critical', metavar='RANGE', default='500:',
+                   help='return critical if file is smaller than RANGE')
+
+    args = a.parse_args()
+    check = nagiosplugin.Check(
+        JournalFile(),
+        nagiosplugin.ScalarContext('critical', critical=args.critical),
+        JournalFileSummary())
+    check.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/nixos/modules/flyingcircus/packages/fcsensuplugins/setup.py
+++ b/nixos/modules/flyingcircus/packages/fcsensuplugins/setup.py
@@ -25,6 +25,7 @@ setup(
         'console_scripts': [
             'check_disk=fc.sensuplugins.disk:main',
             'check_journal=fc.sensuplugins.journal:main',
+            'check_journal_file=fc.sensuplugins.journalfile:main',
             'check_writable=fc.sensuplugins.writable:main'
         ],
     },

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -321,6 +321,11 @@ in {
         command = "${pkgs.fcsensuplugins}/bin/check_journal -v https://bitbucket.org/flyingcircus/fc-logcheck-config/raw/tip/nixos-journal.yaml";
         interval = 600;
       };
+      journal_file = {
+        notification = "Journal file too small. (last 12h)";
+        command = "${pkgs.fcsensuplugins}/bin/check_journal_file";
+        interval = 12 * 3600;
+      };
 
       vulnix = {
         notification = "Security vulnerabilities in the last 6h";


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: creates a nagios check, which ensures /var/log/journal/*/system.log will be bigger than 500 bytes

Changelog:

#26959