### PR TITLE
updates busybox to 1.26

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -9,6 +9,7 @@ in rec {
 
   boost159 = pkgs.callPackage ./boost/1.59.nix { };
   boost160 = pkgs.callPackage ./boost/1.60.nix { };
+  busybox = pkgs.callPackage ./busybox { };
 
   cacert = pkgs.callPackage ./cacert.nix { };
   clamav = pkgs.callPackage ./clamav.nix { };

--- a/nixos/modules/flyingcircus/packages/busybox/busybox-in-store.patch
+++ b/nixos/modules/flyingcircus/packages/busybox/busybox-in-store.patch
@@ -1,0 +1,23 @@
+Allow BusyBox to be invoked as "<something>-busybox". This is
+necessary when it's run from the Nix store as <hash>-busybox during
+stdenv bootstrap.
+--- busybox-1.26.1-orig/libbb/appletlib.orig	2016-10-26 19:54:20.510957575 -0400
++++ busybox-1.26.1/libbb/appletlib.c	2016-10-26 19:48:31.590862853 -0400
+@@ -887,7 +887,7 @@
+ static NORETURN void run_applet_and_exit(const char *name, char **argv)
+ {
+ #  if ENABLE_BUSYBOX
+-	if (is_prefixed_with(name, "busybox"))
++	if (strstr(name, "busybox") != 0)
+ 		exit(busybox_main(argv));
+ #  endif
+ #  if NUM_APPLETS > 0
+@@ -981,7 +981,7 @@ int main(int argc UNUSED_PARAM, char **argv)
+ 
+ 	lbb_prepare("busybox" IF_FEATURE_INDIVIDUAL(, argv));
+ # if !ENABLE_BUSYBOX
+-	if (argv[1] && is_prefixed_with(bb_basename(argv[0]), "busybox"))
++	if (argv[1] && strstr(bb_basename(argv[0]), "busybox") != 0)
+ 		argv++;
+ # endif
+ 	applet_name = argv[0];

--- a/nixos/modules/flyingcircus/packages/busybox/default.nix
+++ b/nixos/modules/flyingcircus/packages/busybox/default.nix
@@ -1,0 +1,84 @@
+{ stdenv, fetchurl, musl
+, enableStatic ? false
+, enableMinimal ? false
+, useMusl ? false
+, extraConfig ? ""
+}:
+
+let
+  configParser = ''
+    function parseconfig {
+        while read LINE; do
+            NAME=`echo "$LINE" | cut -d \  -f 1`
+            OPTION=`echo "$LINE" | cut -d \  -f 2`
+
+            if ! [[ "$NAME" =~ ^CONFIG_ ]]; then continue; fi
+
+            echo "parseconfig: removing $NAME"
+            sed -i /$NAME'\(=\| \)'/d .config
+
+            echo "parseconfig: setting $NAME=$OPTION"
+            echo "$NAME=$OPTION" >> .config
+        done
+    }
+  '';
+
+in
+
+stdenv.mkDerivation rec {
+  name = "busybox-1.26.2";
+
+  src = fetchurl {
+    url = "http://busybox.net/downloads/${name}.tar.bz2";
+    sha256 = "05mg6rh5smkzfwqfcazkpwy6h6555llsazikqnvwkaf17y8l8gns";
+  };
+
+  patches = [ ./busybox-in-store.patch ];
+
+  configurePhase = ''
+    export KCONFIG_NOTIMESTAMP=1
+    make ${if enableMinimal then "allnoconfig" else "defconfig"}
+
+    ${configParser}
+
+    cat << EOF | parseconfig
+
+    CONFIG_PREFIX "$out"
+    CONFIG_INSTALL_NO_USR y
+
+    ${stdenv.lib.optionalString enableStatic ''
+      CONFIG_STATIC y
+    ''}
+
+    # Use the external mount.cifs program.
+    CONFIG_FEATURE_MOUNT_CIFS n
+    CONFIG_FEATURE_MOUNT_HELPERS y
+
+    ${extraConfig}
+    $extraCrossConfig
+    EOF
+
+    make oldconfig
+  '' + stdenv.lib.optionalString useMusl ''
+    makeFlagsArray+=("CC=gcc -isystem ${musl}/include -B${musl}/lib -L${musl}/lib")
+  '';
+
+  crossAttrs = {
+    extraCrossConfig = ''
+      CONFIG_CROSS_COMPILER_PREFIX "${stdenv.cross.config}-"
+    '' +
+      (if stdenv.cross.platform.kernelMajor == "2.4" then ''
+        CONFIG_IONICE n
+      '' else "");
+  };
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Tiny versions of common UNIX utilities in a single small executable";
+    homepage = http://busybox.net/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ viric ];
+    platforms = platforms.linux;
+  };
+}

--- a/nixos/modules/flyingcircus/packages/busybox/default.nix
+++ b/nixos/modules/flyingcircus/packages/busybox/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     description = "Tiny versions of common UNIX utilities in a single small executable";
     homepage = http://busybox.net/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ viric ];
     platforms = platforms.linux;
+    priority = 10;
   };
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: changed the busybox version within the upstream directory as it's outside the regular packages scope

Changelog: 

re #26962
