### PR TITLE
Remove LD_LIBRARY_PATH from default environment

### DIFF
--- a/nixos/modules/flyingcircus/platform/default.nix
+++ b/nixos/modules/flyingcircus/platform/default.nix
@@ -201,15 +201,6 @@ in
     fonts.fontconfig.enable = true;
 
     environment.pathsToLink = [ "/include" ];
-    environment.shellInit = ''
-      # help pip to find libz.so when building lxml
-      export LIBRARY_PATH=/var/run/current-system/sw/lib
-      # help dynamic loading like python-magic to find it's libraries
-      export LD_LIBRARY_PATH=$LIBRARY_PATH
-      # ditto for header files, e.g. sqlite
-      export C_INCLUDE_PATH=/var/run/current-system/sw/include:/var/run/current-system/sw/include/sasl
-    '';
-
     boot.kernelPackages = pkgs.linuxPackages_4_4;
     boot.supportedFilesystems = [ "nfs4" ];
 

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -6,9 +6,11 @@
     environment.systemPackages = with pkgs; [
         apacheHttpd
         atop
+        automake
         bc
         bind
         bundler
+        cmake
         curl
         cyrus_sasl
         db
@@ -18,8 +20,10 @@
         file
         fio
         gcc
+        gdb
         gdbm
         git
+        gnumake
         gnupg
         go
         gptfdisk
@@ -46,12 +50,13 @@
         openldap
         openssl_1_0_2
         php
+        pkgconfig
         protobuf
         psmisc
         pv
         python2Full
-        pythonPackages.virtualenv
         python34
+        pythonPackages.virtualenv
         screen
         strace
         subversion

--- a/nixos/modules/flyingcircus/platform/shell.nix
+++ b/nixos/modules/flyingcircus/platform/shell.nix
@@ -13,24 +13,33 @@ in
       export TMOUT=43200
     '';
 
-    environment.shellInit =
+    environment.shellInit = ''
+      # help building locally compiled programs
+      export LIBRARY_PATH=$HOME/.nix-profile/lib:/run/current-system/sw/lib
+      # header files
+      export CPATH=$HOME/.nix-profile/include:/run/current-system/sw/include
+      export C_INCLUDE_PATH=$CPATH
+      export CPLUS_INCLUDE_PATH=$CPATH
+      # pkg-config
+      export PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig:/run/current-system/sw/lib/pkgconfig
+    '' +
+    (opt
+      (enc ? name && parameters ? location && parameters ? environment)
       # FCIO_* only exported if ENC data is present.
-      (opt
-        (enc ? name && parameters ? location && parameters ? environment)
-        ''
-          # Grant easy access to the machine's ENC data for some variables to
-          # shell scripts.
-          export FCIO_LOCATION="${parameters.location}"
-          export FCIO_ENVIRONMENT="${parameters.environment}"
-          export FCIO_HOSTNAME="${enc.name}"
-        '');
+      ''
+        # Grant easy access to the machine's ENC data for some variables to
+        # shell scripts.
+        export FCIO_LOCATION="${parameters.location}"
+        export FCIO_ENVIRONMENT="${parameters.environment}"
+        export FCIO_HOSTNAME="${enc.name}"
+      '');
 
     users.motd = ''
-        Welcome to the Flying Circus!
+      Welcome to the Flying Circus!
 
-        Status:     http://status.flyingcircus.io/
-        Docs:       https://flyingcircus.io/doc/
-        Release:    ${config.system.nixosVersion}
+      Status:     http://status.flyingcircus.io/
+      Docs:       https://flyingcircus.io/doc/
+      Release:    ${config.system.nixosVersion}
     '' +
     (opt
       (enc ? name && parameters ? location && parameters ? environment


### PR DESCRIPTION
Also prefix LIBRARY_PATH, PKG_CONFIG_PATH and various include paths
with the appropriate user env directories. Thus, packages installed
locally via nix-env or similar tools always take precendence.

Add some commonly used build tools that operate entirely on the call
level, i.e. they do not add link level dependencies to target programs.

Re #25410

@flyingcircusio/release-managers

Impact: Users should restart all applications to detect link-level errors.

Changelog: Remove LD_LIBRARY_PATH from default environment. It causes more harm than good (#25410).
