### PR TITLE
Port XCache 3.2.0 to PHP 5.6

### DIFF
--- a/nixos/modules/flyingcircus/packages/php-packages.nix
+++ b/nixos/modules/flyingcircus/packages/php-packages.nix
@@ -26,4 +26,29 @@ rec {
     ];
   };
 
+  xcache = buildPecl rec {
+    name = "xcache-${version}";
+
+    version = "3.2.0";
+
+    src = pkgs.fetchurl {
+      url = "http://xcache.lighttpd.net/pub/Releases/${version}/${name}.tar.bz2";
+      sha256 = "1gbcpw64da9ynjxv70jybwf9y88idm01kb16j87vfagpsp5s64kx";
+    };
+
+    doCheck = true;
+    checkTarget = "test";
+
+    configureFlags = [
+      "--enable-xcache"
+      "--enable-xcache-coverager"
+      "--enable-xcache-optimizer"
+      "--enable-xcache-assembler"
+      "--enable-xcache-encoder"
+      "--enable-xcache-decoder"
+    ];
+
+    buildInputs = [ pkgs.m4 ];
+  };
+
 }


### PR DESCRIPTION
This allows to install global XCache for php5.6 via phpPackages.xcache

Re #27595
