### PR TITLE
Prebuild pdftk dependencies

### DIFF
--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -19,6 +19,8 @@
 
   oraclejava = hydraJob (import ./oraclejava.nix { inherit system; });
 
+  pdftk = hydraJob (import ./pdftk.nix { inherit system; });
+
   postgresql_9_3 = hydraJob
     (import ./postgresql.nix { rolename = "postgresql93"; });
   postgresql_9_4 = hydraJob

--- a/nixos/modules/flyingcircus/tests/pdftk.nix
+++ b/nixos/modules/flyingcircus/tests/pdftk.nix
@@ -1,0 +1,22 @@
+import ../../../tests/make-test.nix ({ ... }:
+{
+  name = "pdftk";
+  # This test does *not* really test pdftk and causes the
+  # dependencies to be built.
+
+  nodes = {
+    master =
+      { pkgs, config, ... }:
+      {
+
+        virtualisation.memorySize = 512;
+        environment.systemPackages = with pkgs; [
+            pdftk
+        ];
+      };
+  };
+
+  testScript = ''
+    startAll;
+  '';
+})


### PR DESCRIPTION
This PR adds a minimalistic test for pdftk to ensure it's getting build on our hydra 

Re #27590

@flyingcircusio/release-managers
