### PR TITLE
Update coturn 4.5.0.3 -> 4.5.0.6

### DIFF
--- a/nixos/modules/flyingcircus/packages/coturn/default.nix
+++ b/nixos/modules/flyingcircus/packages/coturn/default.nix
@@ -4,13 +4,13 @@ let inherit (stdenv.lib) optional; in
 
 stdenv.mkDerivation rec {
   name = "coturn-${version}";
-  version = "4.5.0.3";
+  version = "4.5.0.6";
 
   src = fetchFromGitHub {
     owner = "coturn";
     repo = "coturn";
     rev = "${version}";
-    sha256 = "1xr4dp3p16m4rq9mdsprs6s50rnif6hk38xx9siyykgfjnwr6i9g";
+    sha256 = "084c3zgwmmz4s6211i5jbkzsn13703lsg7vhc2cpacazq4sgsrhb";
   };
 
   buildInputs = [ openssl libevent ];


### PR DESCRIPTION
This PR updates coturn to a more recent version

Re #27762

@flyingcircusio/release-managers

Impact: coturn-services will be restarted

Changelog: Update coturn from 4.5.0.3 to 4.5.0.6