### PR TITLE
27132 grafana prometheus

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
@@ -2,7 +2,6 @@
 with lib;
 
 let
-  fclib = import ../../lib;
   enc = config.flyingcircus.enc;
   params = if enc ? parameters then enc.parameters else {};
 
@@ -21,7 +20,6 @@ let
 
 in
 mkIf (params ? location && params ? resource_group) {
-
   services.collectd.enable = true;
   services.collectd.extraConfig = ''
     Interval 5
@@ -38,11 +36,6 @@ mkIf (params ? location && params ? resource_group) {
     LoadPlugin syslog
     LoadPlugin vmem
     LoadPlugin write_graphite
-
-    LoadPlugin write_prometheus
-    <Plugin "write_prometheus">
-      Port "9103"
-    </Plugin>
 
     <LoadPlugin uptime>
       Interval 360

--- a/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/collectd.nix
@@ -2,6 +2,7 @@
 with lib;
 
 let
+  fclib = import ../../lib;
   enc = config.flyingcircus.enc;
   params = if enc ? parameters then enc.parameters else {};
 
@@ -20,6 +21,7 @@ let
 
 in
 mkIf (params ? location && params ? resource_group) {
+
   services.collectd.enable = true;
   services.collectd.extraConfig = ''
     Interval 5
@@ -36,6 +38,11 @@ mkIf (params ? location && params ? resource_group) {
     LoadPlugin syslog
     LoadPlugin vmem
     LoadPlugin write_graphite
+
+    LoadPlugin write_prometheus
+    <Plugin "write_prometheus">
+      Port "9103"
+    </Plugin>
 
     <LoadPlugin uptime>
       Interval 360

--- a/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
@@ -13,6 +13,7 @@ in
       <nixpkgs/nixos/modules/profiles/qemu-guest.nix>
       ./collectd.nix
       ./quota.nix
+      ./telegraf.nix
   ];
 
   systemd.services.qemu-guest-agent = {

--- a/nixos/modules/flyingcircus/infrastructure/fcio/telegraf.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/telegraf.nix
@@ -1,0 +1,46 @@
+{ config, pkgs, lib, ... }:
+with lib;
+
+let
+  fclib = import ../../lib;
+  enc = config.flyingcircus.enc;
+  params = if enc ? parameters then enc.parameters else {};
+in
+mkIf (params ? location && params ? resource_group) {
+
+  services.telegraf.enable = true;
+  services.telegraf.extraConfig = {
+    global_tags = {
+        location = params.location;
+        resource_group = params.resource_group;
+    };
+    outputs = {
+      prometheus_client = {
+        listen = "${lib.head(
+          fclib.listenAddressesQuotedV6 config "ethsrv")}:9126";
+      };
+    };
+    inputs = {
+      cpu = {
+        percpu = false;
+        totalcpu = true;
+      };
+      disk = {
+        mount_points = [
+          "/"
+          "/tmp"
+        ];
+      };
+      diskio = {
+        skip_serial_number = true;
+      };
+      kernel = {};
+      mem = {};
+      netstat = {};
+      net = {};
+      processes = {};
+      system = {};
+      swap = {};
+    };
+  };
+}

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -52,6 +52,7 @@ in rec {
   fcmanage = pkgs.callPackage ./fcmanage { };
   fcsensuplugins = pkgs.callPackage ./fcsensuplugins { };
 
+  grafana = pkgs_17_03.grafana;
   graylog = pkgs.callPackage ./graylog.nix { };
 
   http-parser = pkgs.callPackage ./http-parser {
@@ -103,6 +104,8 @@ in rec {
       modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
     };
 
+  nix = pkgs_17_03.nix;
+
   inherit (pkgs.callPackage ./nodejs { libuv = pkgs.libuvVersions.v1_9_1; })
     nodejs4 nodejs6 nodejs7;
 
@@ -141,6 +144,9 @@ in rec {
   postfix = pkgs.callPackage ./postfix/3.0.nix { };
   powerdns = pkgs.callPackage ./powerdns.nix { };
 
+  prometheus = pkgs_17_03.prometheus;
+
+
   qemu = pkgs.callPackage ./qemu/qemu-2.8.nix {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices Cocoa;
     x86Only = true;
@@ -150,6 +156,8 @@ in rec {
   rabbitmq_server = pkgs.callPackage ./rabbitmq-server.nix { };
   rabbitmq_delayed_message_exchange =
     pkgs.callPackage ./rabbitmq_delayed_message_exchange.nix { };
+
+  remarshal = pkgs_17_03.remarshal;
 
   inherit (rust) rustc cargo;
   rustPlatform = pkgs.recurseIntoAttrs (makeRustPlatform rust);
@@ -174,6 +182,8 @@ in rec {
   rustUnstable = rustPlatform;
 
   sensu = pkgs.callPackage ./sensu { };
+
+  telegraf = pkgs_17_03.telegraf;
 
   uchiwa = pkgs.callPackage ./uchiwa { };
 

--- a/nixos/modules/flyingcircus/packages/collectd/default.nix
+++ b/nixos/modules/flyingcircus/packages/collectd/default.nix
@@ -7,6 +7,7 @@
 , libdbi ? null
 , libgcrypt ? null
 , libmemcached ? null, cyrus_sasl ? null
+, libmicrohttpd ? null
 , libmodbus ? null
 , libnotify ? null, gdk_pixbuf ? null
 , liboping ? null
@@ -26,18 +27,18 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "collectd-5.4.3";
+  name = "collectd-5.7.2";
 
   src = fetchurl {
     url = "http://collectd.org/files/${name}.tar.bz2";
-    sha256 = "1na3wwwzn430vw8mvwigjyxjl9d5329jb75sby8gi8yj996csb3b";
+    sha256 = "14p5cc3ys3qfg71xzxfvmxdmz5l4brpbhlmw1fwdda392lia084x";
   };
 
   buildInputs = [
     pkgconfig curl iptables libcredis libdbi libgcrypt libmemcached cyrus_sasl
     libmodbus libnotify gdk_pixbuf liboping libpcap libsigrok libvirt
     lm_sensors libxml2 lvm2 mysql.lib postgresql protobufc rabbitmq-c rrdtool
-    varnish yajl
+    varnish yajl libmicrohttpd
   ];
 
   # for some reason libsigrok isn't auto-detected

--- a/nixos/modules/flyingcircus/roles/elasticsearch.nix
+++ b/nixos/modules/flyingcircus/roles/elasticsearch.nix
@@ -165,6 +165,16 @@ in
 
     };
 
+    services.telegraf.extraConfig = {
+      inputs = {
+        elasticsearch = {
+          servers = ["http://${thisNode}:9200"];
+          cluster_health = true;
+          cluster_stats = true;
+        };
+      };
+    };
+
     services.collectd.extraConfig = ''
       LoadPlugin curl_json
       <Plugin curl_json>

--- a/nixos/modules/flyingcircus/roles/mongodb/default.nix
+++ b/nixos/modules/flyingcircus/roles/mongodb/default.nix
@@ -144,5 +144,14 @@ in
       critical = 63000;
     };
 
+    services.telegraf.extraConfig = {
+      inputs = {
+        mongodb = {
+          servers = ["mongodb://127.0.0.1:27017"];
+          gather_perdb_stats = true;
+        };
+      };
+    };
+
   };
 }

--- a/nixos/modules/flyingcircus/roles/mysql.nix
+++ b/nixos/modules/flyingcircus/roles/mysql.nix
@@ -19,6 +19,11 @@ let
     then "$(${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 12)"
     else "\"${cfg.rootPassword}\"";
 
+  rootPassword =
+    if builtins.pathExists root_password_file
+    then removeSuffix "\n" (builtins.readFile root_password_file)
+    else "";
+
   localConfig =
     if pathExists /etc/local/mysql
     then "!includedir ${/etc/local/mysql}"
@@ -277,5 +282,14 @@ in
         '';
       };
     };
+
+    services.telegraf.extraConfig = {
+      inputs = {
+        mysql = {
+          servers = ["root:${rootPassword}@unix(/run/mysqld/mysqld.sock)/?tls=false"];
+        };
+      };
+    };
+
   };
 }

--- a/nixos/modules/flyingcircus/roles/nginx.nix
+++ b/nixos/modules/flyingcircus/roles/nginx.nix
@@ -126,6 +126,23 @@ let
       ssl_session_timeout 10m;
       ssl_dhparam /etc/ssl/dhparams.pem;
 
+      # Server Status for monitoring:
+      server {
+        listen 127.0.0.1:80 default_server;
+        listen [::1]:80 default_server;
+        access_log off;
+        server_name _;
+        server_name_in_redirect off;
+
+        location /nginx_status {
+          stub_status on;
+          access_log   off;
+          allow 127.0.0.1;
+          allow ::1;
+          deny all;
+         }
+      }
+
       ${localConfig}
 
       ${config.flyingcircus.roles.nginx.httpConfig}
@@ -180,6 +197,15 @@ in
             endscript
         }
     '';
+
+    services.telegraf.extraConfig = {
+      inputs = {
+        nginx = {
+          urls = ["http://localhost:80/nginx_status"];
+        };
+      };
+    };
+
 
     environment.etc = {
 

--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -219,6 +219,14 @@ in
       };
     };
 
+    services.telegraf.extraConfig = {
+      inputs = {
+        postgresql = {
+          address = "host=/tmp user=root sslmode=disable dbname=postgres";
+        };
+      };
+    };
+
   });
 
 }

--- a/nixos/modules/flyingcircus/roles/statshost.nix
+++ b/nixos/modules/flyingcircus/roles/statshost.nix
@@ -237,7 +237,7 @@ in
             }
 
             location / {
-                rewrite . /grafana/ redirect;
+                rewrite ^ /grafana/ redirect;
             }
 
             location /grafana/ {
@@ -254,7 +254,10 @@ in
               listen *:80;
               listen [::]:80;
               server_name ${httpHost};
-              rewrite . https://$server_name$request_uri redirect;
+
+              location / {
+                rewrite ^ https://$server_name$request_uri redirect;
+              }
           }
 
           server {

--- a/nixos/modules/flyingcircus/roles/statshost.nix
+++ b/nixos/modules/flyingcircus/roles/statshost.nix
@@ -23,7 +23,7 @@ let
     else [  # Proxy only
       "-storage.local.retention 24h"
       "-storage.local.series-file-shrink-ratio 0.1"
-      "-storage.local.memory-chunks 1048576"  # Find out useful value.
+      "-storage.local.memory-chunks 131072"  # Find out useful value.
     ];
   prometheusListenAddress =
     "${lib.head(fclib.listenAddressesQuotedV6 config "ethsrv")}:9090";

--- a/nixos/modules/flyingcircus/roles/statshost.nix
+++ b/nixos/modules/flyingcircus/roles/statshost.nix
@@ -211,7 +211,7 @@ in
           honor_labels = true;
           params = {
             "match[]" = [
-              "{job=\"static\"}"
+              "{job=~\"static|prometheus\"}"
             ];
           };
           file_sd_configs = [{

--- a/nixos/modules/flyingcircus/roles/statshost.nix
+++ b/nixos/modules/flyingcircus/roles/statshost.nix
@@ -5,24 +5,68 @@
 with lib;
 
 let
-  cfg = config.flyingcircus.roles.statshost;
-  cfg_proxy = config.flyingcircus.roles.statshostproxy;
+  fclib = import ../lib;
 
-  # can be replaced with pkgs.influxdb once InfluxDB 0.11 is present in upstream
-  # nixpkgs.
-  influxdb = (pkgs.callPackage ../packages/influxdb.nix { }).bin //
-    { outputs = [ "bin" ]; };
+  cfgStatsGlobal = config.flyingcircus.roles.statshost;
+  cfgStatsRG = config.flyingcircus.roles.statshost-master;
+  cfgProxyGlobal = config.flyingcircus.roles.statshostproxy;
+  cfgProxyRG = config.flyingcircus.roles.statshost-relay;
 
-  statshost_service = lib.findFirst
+  prometheus = cfgStatsRG.enable || cfgProxyRG.enable;
+  promFlags =
+    if cfgStatsRG.enable
+    then [
+      "-storage.local.retention 1400h"
+      "-storage.local.series-file-shrink-ratio 0.3"
+      "-storage.local.memory-chunks 1048576"
+    ]
+    else [  # Proxy only
+      "-storage.local.retention 24h"
+      "-storage.local.series-file-shrink-ratio 0.1"
+      "-storage.local.memory-chunks 1048576"  # Find out useful value.
+    ];
+
+  statshostService = lib.findFirst
     (s: s.service == "statshost-collector")
     null
     config.flyingcircus.enc_services;
 
+  grafanaLdapConfig = pkgs.writeText "ldap.toml" ''
+    verbose_logging = true
+
+    [[servers]]
+    host = "ldap.rzob.gocept.net"
+    port = 389
+    start_tls = true
+    bind_dn = "uid=%s,ou=People,dc=gocept,dc=com"
+    search_base_dns = ["ou=People,dc=gocept,dc=com"]
+    search_filter = "(uid=%s)"
+    group_search_base_dns = ["ou=Group,dc=gocept,dc=com"]
+    group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+
+    [servers.attributes]
+    name = "cn"
+    surname = "displaname"
+    username = "uid"
+    member_of = "cn"
+    email = "mail"
+
+    [[servers.group_mappings]]
+    group_dn = "${config.flyingcircus.enc.parameters.resource_group}"
+    org_role = "Admin"
+
+    [[servers.group_mappings]]
+    group_dn = "*"
+    org_role = ""
+
+  '';
+
 in
 {
   options = {
+
     flyingcircus.roles.statshost = {
-      enable = mkEnableOption "Grafana/InfluxDB stats host";
+      enable = mkEnableOption "Grafana/InfluxDB stats host (global)";
 
       useSSL = mkOption {
         type = types.bool;
@@ -47,17 +91,28 @@ in
       enable = mkEnableOption "Enable stats proxy.";
     };
 
+
+    flyingcircus.roles.statshost-master = {
+      enable = mkEnableOption "Grafana/Prometheus stats host for one RG";
+    };
+
+    flyingcircus.roles.statshost-relay = {
+      enable = mkEnableOption "Grafana/Prometheus stats relay";
+    };
+
   };
 
   config = mkMerge [
-    (mkIf cfg.enable {
+
+    # Global stats host. Currently influxdb.
+    (mkIf cfgStatsGlobal.enable {
 
       # make the 'influx' command line tool accessible
-      environment.systemPackages = [ influxdb ];
+      environment.systemPackages = [ pkgs.influxdb ];
 
       services.influxdb011.enable = true;
       services.influxdb011.dataDir = "/srv/influxdb";
-      services.influxdb011.package = influxdb;
+      services.influxdb011.package = pkgs.influxdb;
 
       services.influxdb011.extraConfig = {
         http.enabled = true;
@@ -110,21 +165,70 @@ in
 
       boot.kernel.sysctl."net.core.rmem_max" = 8388608;
 
+      services.collectdproxy.statshost.enable = true;
+      services.collectdproxy.statshost.send_to =
+        "${cfgStatsGlobal.hostName}:2003";
+    })
+
+    # RG-specific statshost. Prometheus
+    (mkIf prometheus {
+
+      environment.etc."local/statshost/scrape-rg.json".text = builtins.toJSON [{
+        targets = builtins.sort builtins.lessThan (lib.unique
+          (map
+            (host: "${host.name}.fcio.net:9126")
+            config.flyingcircus.enc_addresses.srv));
+      }];
+
+      services.prometheus.enable = true;
+      services.prometheus.extraFlags = promFlags;
+      services.prometheus.listenAddress =
+        "${lib.head(fclib.listenAddressesQuotedV6 config "ethsrv")}:9090";
+      services.prometheus.scrapeConfigs = [
+        { job_name = "static";
+          scrape_interval = "15s";
+          file_sd_configs = [{
+            files = ["/etc/local/statshost/scrape-*.json" ];
+            refresh_interval = "10m";
+          }];
+        }
+        { job_name = "fedrate";
+          scrape_interval = "15s";
+          metrics_path = "/federate";
+          honor_labels = true;
+          params = {
+            "match[]" = [
+              "{job=\"static\"}"
+            ];
+          };
+          file_sd_configs = [{
+            files = ["/etc/local/statshost/federate-*.json" ];
+            refresh_interval = "10m";
+          }];
+        }
+      ];
+
+    })
+
+    # Grafana
+    (mkIf (cfgStatsGlobal.enable || cfgStatsRG.enable) {
       services.grafana = {
         enable = true;
         port = 3001;
         addr = "127.0.0.1";
-        rootUrl = "http://${cfg.hostName}/grafana";
+        rootUrl = "http://${cfgStatsGlobal.hostName}/grafana";
+        extraOptions = {
+          AUTH_LDAP_ENABLED = "true";
+          AUTH_LDAP_CONFIG_FILE = toString grafanaLdapConfig;
+          LOG_LEVEL = "debug";
+          LOG_FILTERS = "ldap:debug";
+        };
       };
 
-      services.collectdproxy.statshost.enable = true;
-      services.collectdproxy.statshost.send_to = "${cfg.hostName}:2003";
-
       flyingcircus.roles.nginx.enable = true;
-
       flyingcircus.roles.nginx.httpConfig =
         let
-          httpHost = cfg.hostName;
+          httpHost = cfgStatsGlobal.hostName;
           common = ''
             server_name ${httpHost};
 
@@ -145,7 +249,7 @@ in
             }
           '';
         in
-        if cfg.useSSL then ''
+        if cfgStatsGlobal.useSSL then ''
           server {
               listen *:80;
               listen [::]:80;
@@ -174,11 +278,13 @@ in
 
       networking.firewall.allowedTCPPorts = [ 80 443 2004 ];
       networking.firewall.allowedUDPPorts = [ 2003 ];
+
     })
 
-    (mkIf (cfg_proxy.enable && statshost_service != null) {
+    # collectd proxy
+    (mkIf (cfgProxyGlobal.enable && statshostService != null) {
       services.collectdproxy.location.enable = true;
-      services.collectdproxy.location.statshost = cfg.hostName;
+      services.collectdproxy.location.statshost = cfgStatsGlobal.hostName;
       services.collectdproxy.location.listen_addr = config.networking.hostName;
       networking.firewall.allowedUDPPorts = [ 2003 ];
 

--- a/nixos/modules/flyingcircus/services/default.nix
+++ b/nixos/modules/flyingcircus/services/default.nix
@@ -3,15 +3,17 @@
 {
   imports =
     [
-     ./collectdproxy.nix
      ./clamav.nix
+     ./collectdproxy.nix
      ./coturn.nix
      ./fcmanage.nix
+     ./grafana.nix
      ./graylog.nix
      ./influxdb011.nix
      ./kibana.nix
      ./percona.nix
      ./powerdns.nix
+     ./prometheus
      ./rabbitmq.nix
      ./rsyslog.nix
      ./sensu/api.nix
@@ -19,5 +21,6 @@
      ./sensu/server.nix
      ./sensu/uchiwa.nix
      ./sysstat.nix
+     ./telegraf.nix
     ];
 }

--- a/nixos/modules/flyingcircus/services/grafana.nix
+++ b/nixos/modules/flyingcircus/services/grafana.nix
@@ -1,0 +1,90 @@
+{ options, config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.grafana;
+  fclib = import ../lib;
+
+  b2s = val: if val then "true" else "false";
+
+  envOptions = {
+    PATHS_DATA = cfg.dataDir;
+    PATHS_PLUGINS = "${cfg.dataDir}/plugins";
+    PATHS_LOGS = "${cfg.dataDir}/log";
+
+    SERVER_PROTOCOL = cfg.protocol;
+    SERVER_HTTP_ADDR = cfg.addr;
+    SERVER_HTTP_PORT = cfg.port;
+    SERVER_DOMAIN = cfg.domain;
+    SERVER_ROOT_URL = cfg.rootUrl;
+    SERVER_STATIC_ROOT_PATH = cfg.staticRootPath;
+    SERVER_CERT_FILE = cfg.certFile;
+    SERVER_CERT_KEY = cfg.certKey;
+
+    DATABASE_TYPE = cfg.database.type;
+    DATABASE_HOST = cfg.database.host;
+    DATABASE_NAME = cfg.database.name;
+    DATABASE_USER = cfg.database.user;
+    DATABASE_PASSWORD = cfg.database.password;
+    DATABASE_PATH = cfg.database.path;
+
+    SECURITY_ADMIN_USER = cfg.security.adminUser;
+    SECURITY_ADMIN_PASSWORD = cfg.security.adminPassword;
+    SECURITY_SECRET_KEY = cfg.security.secretKey;
+
+    USERS_ALLOW_SIGN_UP = b2s cfg.users.allowSignUp;
+    USERS_ALLOW_ORG_CREATE = b2s cfg.users.allowOrgCreate;
+    USERS_AUTO_ASSIGN_ORG = b2s cfg.users.autoAssignOrg;
+    USERS_AUTO_ASSIGN_ORG_ROLE = cfg.users.autoAssignOrgRole;
+
+    AUTH_ANONYMOUS_ENABLE = b2s cfg.auth.anonymous.enable;
+    AUTH_ANONYMOUS_ORG_NAME = cfg.auth.anonymous.org_name;
+    AUTH_ANONYMOUS_ORG_ROLE = cfg.auth.anonymous.org_role;
+
+    ANALYTICS_REPORTING_ENABLED = b2s cfg.analytics.reporting.enable;
+  } // cfg.extraOptions;
+
+in {
+  options.services.grafana = {
+
+    auth.anonymous = {
+
+      org_name = mkOption {
+        description = "Which organization to allow anonymous access to";
+        default = "Main Org.";
+        type = types.str;
+      };
+      org_role = mkOption {
+        description = "Which role anonymous users have in the organization";
+        default = "Viewer";
+        type = types.str;
+      };
+
+    };
+
+    analytics.reporting = {
+      enable = mkOption {
+        description = "Whether to allow anonymous usage reporting to stats.grafana.net";
+        default = true;
+        type = types.bool;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.grafana = {
+      environment = mkForce (
+          mapAttrs' (n: v: nameValuePair "GF_${n}" (toString v)) envOptions);
+      serviceConfig = {
+        ExecStart = mkForce "${cfg.package.bin}/bin/grafana-server -homepath ${cfg.dataDir}";
+      };
+      preStart = mkForce ''
+        ${pkgs.coreutils}/bin/ln -fs ${cfg.package}/share/grafana/conf ${cfg.dataDir}
+        ${pkgs.coreutils}/bin/ln -fs ${cfg.package}/share/grafana/vendor ${cfg.dataDir}
+      '';
+    };
+
+  };
+}

--- a/nixos/modules/flyingcircus/services/prometheus/default.nix
+++ b/nixos/modules/flyingcircus/services/prometheus/default.nix
@@ -1,0 +1,474 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus;
+  promUser = "prometheus";
+  promGroup = "prometheus";
+
+  # Get a submodule without any embedded metadata:
+  _filter = x: filterAttrs (k: v: k != "_module") x;
+
+  # Pretty-print JSON to a file
+  writePrettyJSON = name: x:
+    pkgs.runCommand name { } ''
+      echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out
+    '';
+
+  # This becomes the main config file
+  promConfig = {
+    global = cfg.globalConfig;
+    rule_files = cfg.ruleFiles ++ [
+      (pkgs.writeText "prometheus.rules" (concatStringsSep "\n" cfg.rules))
+    ];
+    scrape_configs = cfg.scrapeConfigs;
+  };
+
+  generatedPrometheusYml = writePrettyJSON "prometheus.yml" promConfig;
+
+  prometheusYml =
+    if cfg.configText != null then
+      pkgs.writeText "prometheus.yml" cfg.configText
+    else generatedPrometheusYml;
+
+  cmdlineArgs = cfg.extraFlags ++ [
+    "-storage.local.path=${cfg.dataDir}/metrics"
+    "-config.file=${prometheusYml}"
+    "-web.listen-address=${cfg.listenAddress}"
+    "-alertmanager.notification-queue-capacity=${toString cfg.alertmanagerNotificationQueueCapacity}"
+    "-alertmanager.timeout=${toString cfg.alertmanagerTimeout}s"
+    (optionalString (cfg.alertmanagerURL != []) "-alertmanager.url=${concatStringsSep "," cfg.alertmanagerURL}")
+  ];
+
+  promTypes.globalConfig = types.submodule {
+    options = {
+      scrape_interval = mkOption {
+        type = types.str;
+        default = "1m";
+        description = ''
+          How frequently to scrape targets by default.
+        '';
+      };
+
+      scrape_timeout = mkOption {
+        type = types.str;
+        default = "10s";
+        description = ''
+          How long until a scrape request times out.
+        '';
+      };
+
+      evaluation_interval = mkOption {
+        type = types.str;
+        default = "1m";
+        description = ''
+          How frequently to evaluate rules by default.
+        '';
+      };
+
+      labels = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = ''
+          The labels to add to any timeseries that this Prometheus instance
+          scrapes.
+        '';
+      };
+    };
+  };
+
+  promTypes.scrape_config = types.submodule {
+    options = {
+      job_name = mkOption {
+        type = types.str;
+        description = ''
+          The job name assigned to scraped metrics by default.
+        '';
+      };
+      scrape_interval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          How frequently to scrape targets from this job. Defaults to the
+          globally configured default.
+        '';
+      };
+      scrape_timeout = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Per-target timeout when scraping this job. Defaults to the
+          globally configured default.
+        '';
+      };
+      metrics_path = mkOption {
+        type = types.str;
+        default = "/metrics";
+        description = ''
+          The HTTP resource path on which to fetch metrics from targets.
+        '';
+      };
+      scheme = mkOption {
+        type = types.enum ["http" "https"];
+        default = "http";
+        description = ''
+          The URL scheme with which to fetch metrics from targets.
+        '';
+      };
+      params = mkOption {
+        type = types.nullOr types.attrs ;
+        default = null;
+      };
+      honor_labels = mkOption {
+        type = types.bool;
+        default = false;
+      };
+      basic_auth = mkOption {
+        type = types.nullOr (types.submodule {
+          options = {
+            username = mkOption {
+              type = types.str;
+              description = ''
+                HTTP username
+              '';
+            };
+            password = mkOption {
+              type = types.str;
+              description = ''
+                HTTP password
+              '';
+            };
+          };
+        });
+        default = null;
+        apply = x: if x == null then null else _filter x;
+        description = ''
+          Optional http login credentials for metrics scraping.
+        '';
+      };
+      dns_sd_configs = mkOption {
+        type = types.listOf promTypes.dns_sd_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          List of DNS service discovery configurations.
+        '';
+      };
+      consul_sd_configs = mkOption {
+        type = types.listOf promTypes.consul_sd_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          List of Consul service discovery configurations.
+        '';
+      };
+      file_sd_configs = mkOption {
+        type = types.listOf promTypes.file_sd_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          List of file service discovery configurations.
+        '';
+      };
+      static_configs = mkOption {
+        type = types.listOf promTypes.static_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          List of labeled target groups for this job.
+        '';
+      };
+      relabel_configs = mkOption {
+        type = types.listOf promTypes.relabel_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          List of relabel configurations.
+        '';
+      };
+    };
+  };
+
+  promTypes.static_config = types.submodule {
+    options = {
+      targets = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          The targets specified by the target group.
+        '';
+      };
+      labels = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = ''
+          Labels assigned to all metrics scraped from the targets.
+        '';
+      };
+    };
+  };
+
+  promTypes.dns_sd_config = types.submodule {
+    options = {
+      names = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          A list of DNS SRV record names to be queried.
+        '';
+      };
+      refresh_interval = mkOption {
+        type = types.str;
+        default = "30s";
+        description = ''
+          The time after which the provided names are refreshed.
+        '';
+      };
+    };
+  };
+
+  promTypes.consul_sd_config = types.submodule {
+    options = {
+      server = mkOption {
+        type = types.str;
+        description = "Consul server to query.";
+      };
+      token = mkOption {
+        type = types.nullOr types.str;
+        description = "Consul token";
+      };
+      datacenter = mkOption {
+        type = types.nullOr types.str;
+        description = "Consul datacenter";
+      };
+      scheme = mkOption {
+        type = types.nullOr types.str;
+        description = "Consul scheme";
+      };
+      username = mkOption {
+        type = types.nullOr types.str;
+        description = "Consul username";
+      };
+      password = mkOption {
+        type = types.nullOr types.str;
+        description = "Consul password";
+      };
+
+      services = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          A list of services for which targets are retrieved.
+        '';
+      };
+      tag_separator = mkOption {
+        type = types.str;
+        default = ",";
+        description = ''
+          The string by which Consul tags are joined into the tag label.
+        '';
+      };
+    };
+  };
+
+  promTypes.file_sd_config = types.submodule {
+    options = {
+      files = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          Patterns for files from which target groups are extracted. Refer
+          to the Prometheus documentation for permitted filename patterns
+          and formats.
+
+        '';
+      };
+      refresh_interval = mkOption {
+        type = types.str;
+        default = "30s";
+        description = ''
+          Refresh interval to re-read the files.
+        '';
+      };
+    };
+  };
+
+  promTypes.relabel_config = types.submodule {
+    options = {
+      source_labels = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          The source labels select values from existing labels. Their content
+          is concatenated using the configured separator and matched against
+          the configured regular expression.
+        '';
+      };
+      separator = mkOption {
+        type = types.str;
+        default = ";";
+        description = ''
+          Separator placed between concatenated source label values.
+        '';
+      };
+      target_label = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Label to which the resulting value is written in a replace action.
+          It is mandatory for replace actions.
+        '';
+      };
+      regex = mkOption {
+        type = types.str;
+        default = "(.*)";
+        description = ''
+          Regular expression against which the extracted value is matched.
+        '';
+      };
+      replacement = mkOption {
+        type = types.str;
+        default = "$1";
+        description = ''
+          Replacement value against which a regex replace is performed if the
+          regular expression matches.
+        '';
+      };
+      action = mkOption {
+        type = types.enum ["replace" "keep" "drop"];
+        default = "replace";
+        description = ''
+          Action to perform based on regex matching.
+        '';
+      };
+    };
+  };
+
+in {
+  options = {
+    services.prometheus = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the Prometheus monitoring daemon.
+        '';
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0:9090";
+        description = ''
+          Address to listen on for the web interface, API, and telemetry.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/prometheus";
+        description = ''
+          Directory to store Prometheus metrics data.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Extra commandline options when launching Prometheus.
+        '';
+      };
+
+      configText = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = ''
+          If non-null, this option defines the text that is written to
+          prometheus.yml. If null, the contents of prometheus.yml is generated
+          from the structured config options.
+        '';
+      };
+
+      globalConfig = mkOption {
+        type = promTypes.globalConfig;
+        default = {};
+        apply = _filter;
+        description = ''
+          Parameters that are valid in all  configuration contexts. They
+          also serve as defaults for other configuration sections
+        '';
+      };
+
+      rules = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Alerting and/or Recording rules to evaluate at runtime.
+        '';
+      };
+
+      ruleFiles = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          Any additional rules files to include in this configuration.
+        '';
+      };
+
+      scrapeConfigs = mkOption {
+        type = types.listOf promTypes.scrape_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          A list of scrape configurations.
+        '';
+      };
+
+      alertmanagerURL = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          List of Alertmanager URLs to send notifications to.
+        '';
+      };
+
+      alertmanagerNotificationQueueCapacity = mkOption {
+        type = types.int;
+        default = 10000;
+        description = ''
+          The capacity of the queue for pending alert manager notifications.
+        '';
+      };
+
+      alertmanagerTimeout = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''
+          Alert manager HTTP API timeout (in seconds).
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.extraGroups.${promGroup}.gid = config.ids.gids.prometheus;
+    users.extraUsers.${promUser} = {
+      description = "Prometheus daemon user";
+      uid = config.ids.uids.prometheus;
+      group = promGroup;
+      home = cfg.dataDir;
+      createHome = true;
+    };
+    systemd.services.prometheus = {
+      wantedBy = [ "multi-user.target" ];
+      after    = [ "network.target" ];
+      script = ''
+        #!/bin/sh
+        exec ${pkgs.prometheus}/bin/prometheus \
+          ${concatStringsSep " \\\n  " cmdlineArgs}
+      '';
+      serviceConfig = {
+        User = promUser;
+        Restart  = "always";
+        WorkingDirectory = cfg.dataDir;
+      };
+    };
+  };
+}

--- a/nixos/modules/flyingcircus/services/telegraf.nix
+++ b/nixos/modules/flyingcircus/services/telegraf.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.telegraf;
+
+  configFile = pkgs.runCommand "config.toml" {
+    buildInputs = [ pkgs.remarshal ];
+  } ''
+    remarshal -if json -of toml \
+      < ${pkgs.writeText "config.json" (builtins.toJSON cfg.extraConfig)} \
+      > $out
+  '';
+in {
+  ###### interface
+  options = {
+    services.telegraf = {
+      enable = mkEnableOption "telegraf server";
+
+      package = mkOption {
+        default = pkgs.telegraf;
+        defaultText = "pkgs.telegraf";
+        description = "Which telegraf derivation to use";
+        type = types.package;
+      };
+
+      extraConfig = mkOption {
+        default = {};
+        description = "Extra configuration options for telegraf";
+        type = types.attrs;
+        example = {
+          outputs = {
+            influxdb = {
+              urls = ["http://localhost:8086"];
+              database = "telegraf";
+            };
+          };
+          inputs = {
+            statsd = {
+              service_address = ":8125";
+              delete_timings = true;
+            };
+          };
+        };
+      };
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf config.services.telegraf.enable {
+    systemd.services.telegraf = {
+      description = "Telegraf Agent";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      serviceConfig = {
+        ExecStart=''${cfg.package}/bin/telegraf -config "${configFile}"'';
+        ExecReload="${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        User = "telegraf";
+        Restart = "on-failure";
+      };
+    };
+
+    users.extraUsers = [{
+      name = "telegraf";
+      uid = config.ids.uids.telegraf;
+      description = "telegraf daemon user";
+    }];
+  };
+}

--- a/nixos/modules/flyingcircus/services/telegraf.nix
+++ b/nixos/modules/flyingcircus/services/telegraf.nix
@@ -28,7 +28,7 @@ in {
       extraConfig = mkOption {
         default = {};
         description = "Extra configuration options for telegraf";
-        type = types.attrs;
+        type = types.attrsOf types.attrs;
         example = {
           outputs = {
             influxdb = {

--- a/nixos/modules/flyingcircus/static/default.nix
+++ b/nixos/modules/flyingcircus/static/default.nix
@@ -104,6 +104,8 @@ with lib;
       # Sames as upstream/master, but not yet merged
       kibana = 211;
       turnserver = 249;
+      prometheus = 255;
+      telegraf = 256;
 
       # Our custom services
       sensuserver = 31001;
@@ -118,6 +120,10 @@ with lib;
       users = 100;
       # The generic 'service' GID is different from Gentoo.
       # But 101 is already used in NixOS.
+
+      # Sames as upstream/master, but not yet merged
+      prometheus = 255;
+
       service = 900;
 
       # Sames as upstream/master, but not yet merged

--- a/nixos/modules/flyingcircus/tests/mariadb.nix
+++ b/nixos/modules/flyingcircus/tests/mariadb.nix
@@ -20,7 +20,6 @@ import ../../../tests/make-test.nix ({ pkgs, ... }:
         imports = [
           ./setup.nix
           ../platform
-          ../roles/postgresql.nix
           ../services/fcmanage.nix
           ../services/sensu/client.nix
           ../static

--- a/nixos/modules/flyingcircus/tests/postgresql.nix
+++ b/nixos/modules/flyingcircus/tests/postgresql.nix
@@ -10,6 +10,7 @@ import ../../../tests/make-test.nix ({ rolename, lib, pkgs, ... }:
         ../roles/postgresql.nix
         ../services/fcmanage.nix
         ../services/sensu/client.nix
+        ../services/telegraf.nix
         ../static
       ];
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: Add roles for customer-specific Grafana and Prometheus, to access system metrics. (#27132)
Changelog: Update collectd to 5.7.2 (#27132)
Changelog: Use Telegraf to gather additional system metrics. Telegraf will replace collectd in a  subsequent release. (#27132)
