### PR TITLE
webproxy: adds network.target as a requirement for varnish

### DIFF
--- a/nixos/modules/flyingcircus/roles/webproxy.nix
+++ b/nixos/modules/flyingcircus/roles/webproxy.nix
@@ -40,6 +40,8 @@ in
          (fclib.listenAddressesQuotedV6 config "lo"));
     services.varnish.config = varnishCfg;
     services.varnish.stateDir = "/var/spool/varnish/${config.networking.hostName}";
+    # XXX: needs to be migrated to varnish service
+    systemd.services.varnish.after = [ "network.target" ];
 
     system.activationScripts.varnish = ''
       install -d -o ${toString config.ids.uids.varnish} -g service -m 02775 /etc/local/varnish


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: let varnish wait to network.target be settled

Changelog:

re #27558
