### PR TITLE
Fix "channel activate in maintenance" mode

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcmanage/setup.cfg
+++ b/nixos/modules/flyingcircus/packages/fcmanage/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 addopts = --showlocals --ignore=lib --ignore=lib64

--- a/nixos/modules/flyingcircus/services/fcmanage.nix
+++ b/nixos/modules/flyingcircus/services/fcmanage.nix
@@ -7,20 +7,24 @@ with lib;
 
 let
   cfg = config.flyingcircus;
+  defaultUpdateAction =
+    if cfg.agent.with-maintenance then "--channel-with-maintenance" else "--channel";
 
 in {
   options = {
 
     flyingcircus.agent = {
-      enable = mkOption {
-        type = types.bool;
-        default = true;
-        description = "Enable automatically running the Flying Circus management agent.";
+      enable = mkEnableOption "automatic runs of the Flying Circus management agent";
+
+      with-maintenance = mkOption {
+        default = false;
+        description = "Perform NixOS updates in scheduled maintenance.";
+        type = lib.types.bool;
       };
 
       steps = mkOption {
         type = types.str;
-        default = "--directory --system-state --maintenance --channel";
+        default = "--directory --system-state --maintenance ${defaultUpdateAction}";
         description = "Steps to run by the agent.";
       };
     };


### PR DESCRIPTION
Improve maintenance message.

The feature switch has now been migrated to a NixOS configuration
option:

flyingcircus.agent.with-maintenance

The old feature switch /etc/local/build-with-maintenance is now being
ignored.

Re #26699

@flyingcircusio/release-managers

Impact: Improve "channel activate in maintenance" mode (#26699)

Changelog:
