### PR TITLE
Remove unused xxdiff and thus gstreamer dependency

### DIFF
--- a/nixos/modules/flyingcircus/packages/percona/xtrabackup.nix
+++ b/nixos/modules/flyingcircus/packages/percona/xtrabackup.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
      ncurses
      percona
      vim
-     xxdiff
      ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
 to get rid of insecure gstreamer that isn't used otherwise.

Fixes #28030

@flyingcircusio/release-managers

Impact:

Changelog:

* Remove unused dependency on old gstreamer which has an unfixed vulnerability (https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-9447)