### PR TITLE
Security update for libgcrypt: 1.6.4 -> 1.6.6

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -3,11 +3,11 @@
 assert enableCapabilities -> stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "libgcrypt-1.6.4";
+  name = "libgcrypt-1.6.6";
 
   src = fetchurl {
     url = "mirror://gnupg/libgcrypt/${name}.tar.bz2";
-    sha256 = "09k06gs27gxfha07sa9rpf4xh6mvphj9sky7n09ymx75w9zjrg69";
+    sha256 = "1l049fpsjqq5mcdn8fzalf4qwh8dflaqjildm1rv4y5v3531nipr";
   };
 
   buildInputs =


### PR DESCRIPTION
Fixes #27181

@flyingcircusio/release-managers

Impact:

Changelog:

- Apply security update for libcrypt (CVE-2016-6313, https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-6313) 