### PR TITLE
Security update for libarchive: 3.1.2 -> 3.3.2

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -2,20 +2,14 @@
 , sharutils }:
 
 stdenv.mkDerivation rec {
-  name = "libarchive-3.1.2";
+  name = "libarchive-3.3.2";
 
   src = fetchurl {
     urls = [
-      "http://pkgs.fedoraproject.org/repo/pkgs/libarchive/libarchive-3.1.2.tar.gz/efad5a503f66329bb9d2f4308b5de98a/${name}.tar.gz"
       "${meta.homepage}/downloads/${name}.tar.gz"
     ];
-    sha256 = "0pixqnrcf35dnqgv0lp7qlcw7k13620qkhgxr288v7p4iz6ym1zb";
+    sha256 = "1km0mzfl6in7l5vz9kl09a88ajx562rw93ng9h2jqavrailvsbgd";
   };
-
-  patches = [
-    ./CVE-2013-0211.patch # https://github.com/libarchive/libarchive/commit/22531545
-    ./CVE-2015-1197.patch # https://github.com/NixOS/nixpkgs/issues/6799
-  ];
 
   buildInputs = [ sharutils libxml2 zlib bzip2 openssl xz ] ++
     stdenv.lib.optionals stdenv.isLinux [ e2fsprogs attr acl ];
@@ -33,7 +27,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       This library has code for detecting and reading many archive formats and
       compressions formats including (but not limited to) tar, shar, cpio, zip, and
-      compressed with gzip, bzip2, lzma, xz, .. 
+      compressed with gzip, bzip2, lzma, xz, ..
     '';
     homepage = http://libarchive.org;
     license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
Fixes #23890

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for libarchive (https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2304)