### PR TITLE
Security update for rubygems: 2.4.1 -> 2.4.8

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems.nix
+++ b/pkgs/development/interpreters/ruby/rubygems.nix
@@ -1,11 +1,11 @@
-args : with args; 
+args : with args;
 
 rec {
   name = "rubygems-" + version;
-  version = "2.4.1";
+  version = "2.4.8";
   src = fetchurl {
     url = "http://production.cf.rubygems.org/rubygems/${name}.tgz";
-    sha256 = "0cpr6cx3h74ykpb0cp4p4xg7a8j0bhz3sk271jq69l4mm4zy4h4f";
+    sha256 = "0pl4civyf0vhqsqbqaivvxrb3fsg8sid9a8jv5vfnk4hypz3ahss";
   };
 
   buildInputs = [ruby makeWrapper];
@@ -23,7 +23,7 @@ rec {
 
   /* doConfigure should be specified separately */
   phaseNames = ["doPatch" "doInstall"];
-      
+
   meta = {
     description = "Ruby gems package collection";
     longDescription = ''


### PR DESCRIPTION
Fixes #26900

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for rubygems (https://nvd.nist.gov/vuln/detail/CVE-2015-3900 and https://nvd.nist.gov/vuln/detail/CVE-2015-4020)