### PR TITLE
Security update for libxslt: 1.1.28 -> 1.1.29

### DIFF
--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,21 +1,14 @@
 { stdenv, fetchurl, fetchpatch, libxml2, findXMLCatalogs }:
 
 stdenv.mkDerivation rec {
-  name = "libxslt-1.1.28";
+  name = "libxslt-1.1.29";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${name}.tar.gz";
-    sha256 = "13029baw9kkyjgr7q3jccw2mz38amq7mmpr5p3bh775qawd1bisz";
+    sha256 = "1klh81xbm9ppzgqk339097i39b7fnpmlj8lzn8bpczl3aww6x5xm";
   };
 
-  patches = stdenv.lib.optional stdenv.isSunOS ./patch-ah.patch
-    ++ [
-      (fetchpatch {
-        name = "CVE-2015-7995.patch";
-        url = "http://git.gnome.org/browse/libxslt/patch/?id=7ca19df892ca22";
-        sha256 = "1xzg0q94dzbih9nvqp7g9ihz0a3qb0w23l1158m360z9smbi8zbd";
-      })
-    ];
+  patches = stdenv.lib.optional stdenv.isSunOS ./patch-ah.patch;
 
   outputs = [ "out" "doc" ];
 


### PR DESCRIPTION
Fixes #26902

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for libxslt (https://nvd.nist.gov/vuln/detail/CVE-2016-1683 and https://nvd.nist.gov/vuln/detail/CVE-2016-1684)