### PR TITLE
27810 nfs workaround

### DIFF
--- a/nixos/modules/flyingcircus/roles/nfs.nix
+++ b/nixos/modules/flyingcircus/roles/nfs.nix
@@ -18,7 +18,7 @@ let
 
   export = "/srv/nfs/shared";
   mountpoint = "/mnt/nfs";
-  mountopts = "rw,soft,intr,rsize=8192,wsize=8192,noauto,x-systemd.automount";
+  mountopts = "rw,soft,intr,rsize=8192,wsize=8192,vers=4,noauto,x-systemd.automount";
 
   service_clients = filter
     (s: s.service == "nfs_rg_share-server")

--- a/nixos/modules/flyingcircus/roles/nfs.nix
+++ b/nixos/modules/flyingcircus/roles/nfs.nix
@@ -66,14 +66,11 @@ in
 
   config = mkMerge [
     (mkIf (cfg.roles.nfs_rg_client.enable && service ? address) {
-      # work around kernel bug, see #27810
-      boot.blacklistedKernelModules = [ "rpcsec_gss_krb5" ];
-
       fileSystems = {
         "${mountpoint}/shared" = {
           device = "${service.address}:${export}";
           fsType = "nfs4";
-          options = mountopts;
+          options = "${mountopts},nfsvers=4";
           noCheck = true;
         };
       };
@@ -81,11 +78,6 @@ in
       systemd.tmpfiles.rules = [
         "d ${mountpoint}"
       ];
-
-      services.logrotate.config = ''
-        /var/log/autofs {
-        }
-      '';
     })
 
     (mkIf (cfg.roles.nfs_rg_share.enable && service_clients != []) {


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: NFS clients will be restarted on RG share clients. Expect spurious error messages.

Changelog: Downgrade NFS version for RG share clients to work around a hard-to-reproduce NFS bug.

Re #27810
