### PR TITLE
Security update for Perl 5.22.

### DIFF
--- a/pkgs/development/interpreters/perl/5.22/default.nix
+++ b/pkgs/development/interpreters/perl/5.22/default.nix
@@ -21,11 +21,11 @@ in
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "perl-5.22.0";
+  name = "perl-5.22.3";
 
   src = fetchurl {
     url = "mirror://cpan/src/5.0/${name}.tar.gz";
-    sha256 = "0g5bl8sdpzx9gx2g5jq3py4bj07z2ylk7s1qn0fvsss2yl3hhs8c";
+    sha256 = "10q087l1ffdy3gpryr8z540jcnsr0dhm37raicyfqqkyvys1yd8v";
   };
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
5.20 never got fixed. Will upgrade with next NixOS version.

Fixes #24076

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for Perl 5.22. (https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1238)