### PR TITLE
Security update for iptables.

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -63,6 +63,9 @@ in rec {
     ghostscript = null;
   };
   imagemagickBig = pkgs.callPackage ./ImageMagick { };
+
+  iptables = pkgs_17_03.iptables;
+
   influxdb = pkgs.callPackage ./influxdb.nix { };
   innotop = pkgs.callPackage ./percona/innotop.nix { };
 


### PR DESCRIPTION
Fixes #23877.

@flyingcircusio/release-managers

Impact:

* (Maybe) restart networking and firewalling and dependent services on NixOS nodes.

Changelog:

* Security update for iptables.