### PR TITLE
allow dns traffic during firewall configuration, making the firewall …

### DIFF
--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -206,6 +206,10 @@ let
     ip46tables -N nixos-drop
     ip46tables -A nixos-drop -j DROP
 
+    # FCIO: Allow DNS during firewall reload
+    ip46tables -A nixos-drop -p udp --sport 53 -j ACCEPT
+    ip46tables -A nixos-drop -p udp --dport 53 -j ACCEPT
+
     # Don't allow traffic to leak out until the script has completed
     ip46tables -A INPUT -j nixos-drop
     if ${startScript}; then


### PR DESCRIPTION
…configuration a lot easier

re #27132

@flyingcircusio/release-managers

Impact:

Changelog: Firewall: DNS traffic is allowed while the firewall is being reconfigured now. (#27132)
