### PR TITLE
Fix graylog configuration activation

### DIFF
--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -54,6 +54,7 @@
         protobuf
         psmisc
         pv
+        pwgen
         python2Full
         python34
         pythonPackages.virtualenv

--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -231,6 +231,7 @@ in
          description = "Enable Inputs for Graylog";
          requires = [ "graylog.service" ];
          after = [ "graylog.service" "mongodb.service" "elasticsearch.service" ];
+         wantedBy = [ "multi-user.target" ];
          serviceConfig = {
            Type = "oneshot";
            User = config.services.graylog.user;

--- a/nixos/modules/flyingcircus/services/graylog.nix
+++ b/nixos/modules/flyingcircus/services/graylog.nix
@@ -178,6 +178,23 @@ in
         mkdir -p ${cfg.messageJournalDir} -m 755
         chown -R ${cfg.user} ${cfg.messageJournalDir}
       '';
+      postStart = ''
+        # Wait until GL is available for use
+        count=0
+        while true;
+        do
+            ${pkgs.curl}/bin/curl -s ${cfg.webListenUri} && break
+            if [ $count -eq 30 ]
+            then
+                echo "Tried 30 times, giving up..."
+                exit 1
+            fi
+
+            echo "Graylog not yet started. Waiting for 1 second..."
+            count=$((count++))
+            sleep 1
+        done
+      '';
       serviceConfig = {
         User="${cfg.user}";
         PermissionsStartOnly=true;


### PR DESCRIPTION
The config script was never started automatically, hence pretty useles. Graylog waits now until it's http port is ready. The config script will be started afterwards.

@flyingcircusio/release-managers

Impact:

Changelog: Apply initial loghost configuration automatically upon role activation.
