### PR TITLE
Add explicit port checks for all postgresql listening ports.

### DIFF
--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -217,7 +217,17 @@ in
         notification = "PostgreSQL alive";
         command =  "/var/setuid-wrappers/sudo -u postgres check-postgres-alive.rb -d postgres";
       };
-    };
+    } // lib.listToAttrs (
+      map (host:
+          let sane_host = replaceStrings [":"] ["_"] host;
+          in
+          { name = "postgresql-listen-${sane_host}-5432";
+            value = {
+              notification = "PostgreSQL listening on ${host}:5432";
+              command =  "check-ports.rb -h ${host} -p 5432";
+              };
+          })
+        listen_addresses);
 
     services.telegraf.inputs = {
       postgresql = [{


### PR DESCRIPTION
Fixes #28247

@flyingcircusio/release-managers

Impact:

Changelog:

* PostgreSQL: monitor every single listening port to ensure we notice inconsistent states after restarts. (Fixes #28247)
