### PR TITLE
Ensure correct dependencies for PostgreSQL wrt/ networking.

### DIFF
--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -117,18 +117,24 @@ in
     systemd.services.postgresql.after = [ "network-interfaces.target" ];
     systemd.services.postgresql.wants = [ "network-interfaces.target" ];
 
-
-    systemd.services.postgresql.postStart = ''
-      { ${postgresqlPkg}/bin/psql -c '\du' template1 | grep -q '^ *nagios *|'; } || ${postgresqlPkg}/bin/psql -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
-
-      { ${postgresqlPkg}/bin/psql -l | grep -q '^ *nagios *|'; } || ${postgresqlPkg}/bin/createdb nagios
-      ${postgresqlPkg}/bin/psql -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
+    systemd.services.postgresql.postStart =
+    let
+      psql = "${postgresqlPkg}/bin/psql";
+    in ''
+      if ! ${psql} -c '\du' template1 | grep -q '^ *nagios *|'; then
+        ${psql} -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
+      fi
+      if ! ${psql} -l | grep -q '^ *nagios *|'; then
+        ${postgresqlPkg}/bin/createdb nagios
+      fi
+      ${psql} -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
     '';
 
     users.users.postgres = {
       shell = "/run/current-system/sw/bin/bash";
       home = "/srv/postgresql";
     };
+
     system.activationScripts.flyingcircus_postgresql = ''
       install -d -o ${toString config.ids.uids.postgres} /srv/postgresql
       install -d -o ${toString config.ids.uids.postgres} -g service -m 02775 \
@@ -225,13 +231,13 @@ in
       # authenticated access for others
       host all  all  0.0.0.0/0  md5
       host all  all  ::/0       md5
-
     '';
 
     flyingcircus.services.sensu-client.checks = {
       postgresql = {
         notification = "PostgreSQL alive";
-        command =  "/var/setuid-wrappers/sudo -u postgres check-postgres-alive.rb -d postgres";
+        command = "/var/setuid-wrappers/sudo -u postgres check-postgres-alive.rb -d postgres";
+        interval = 120;
       };
     } // lib.listToAttrs (
       map (host:
@@ -240,8 +246,9 @@ in
           { name = "postgresql-listen-${sane_host}-5432";
             value = {
               notification = "PostgreSQL listening on ${host}:5432";
-              command =  " check-postgres-alive.rb -h ${host} -u nagios -d nagios -P 5432";
-              };
+              command = "check-postgres-alive.rb -h ${host} -u nagios -d nagios -P 5432";
+              interval = 120;
+            };
           })
         listen_addresses);
 
@@ -252,5 +259,4 @@ in
     };
 
   });
-
 }

--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -114,6 +114,16 @@ in
 
     services.postgresql.initialScript = ./postgresql-init.sql;
     services.postgresql.dataDir = "/srv/postgresql/${version}";
+    systemd.services.postgresql.after = [ "network-interfaces.target" ];
+    systemd.services.postgresql.wants = [ "network-interfaces.target" ];
+
+
+    systemd.services.postgresql.postStart = ''
+      { ${postgresqlPkg}/bin/psql -c '\du' template1 | grep -q '^ *nagios *|'; } || ${postgresqlPkg}/bin/psql -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
+
+      { ${postgresqlPkg}/bin/psql -l | grep -q '^ *nagios *|'; } || ${postgresqlPkg}/bin/createdb nagios
+      ${postgresqlPkg}/bin/psql -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
+    '';
 
     users.users.postgres = {
       shell = "/run/current-system/sw/bin/bash";
@@ -124,6 +134,7 @@ in
       install -d -o ${toString config.ids.uids.postgres} -g service -m 02775 \
         /etc/local/postgresql/${version}
     '';
+
     security.sudo.extraConfig = ''
       # Service users may switch to the postgres system user
       %sudo-srv ALL=(postgres) ALL
@@ -208,8 +219,13 @@ in
 
     services.postgresql.authentication = ''
       local postgres root       trust
+      # trusted access for Nagios
+      host    nagios          nagios          0.0.0.0/0               trust
+      host    nagios          nagios          ::/0                    trust
+      # authenticated access for others
       host all  all  0.0.0.0/0  md5
       host all  all  ::/0       md5
+
     '';
 
     flyingcircus.services.sensu-client.checks = {
@@ -224,7 +240,7 @@ in
           { name = "postgresql-listen-${sane_host}-5432";
             value = {
               notification = "PostgreSQL listening on ${host}:5432";
-              command =  "check-ports.rb -h ${host} -p 5432";
+              command =  " check-postgres-alive.rb -h ${host} -u nagios -d nagios -P 5432";
               };
           })
         listen_addresses);

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -232,6 +232,9 @@ in {
 
     systemd.services.sensu-client = {
       wantedBy = [ "multi-user.target" ];
+      requires = [ "network-interfaces.target" ];
+      after = [ "network-interfaces.target" ];
+
       path = [
         pkgs.bash
         pkgs.coreutils

--- a/nixos/modules/flyingcircus/services/telegraf.nix
+++ b/nixos/modules/flyingcircus/services/telegraf.nix
@@ -70,7 +70,7 @@ in {
     systemd.services.telegraf = {
       description = "Telegraf Agent";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
+      after = [ "network-interfaces.target" ];
       serviceConfig = {
         ExecStart=''${cfg.package}/bin/telegraf ${startupOptions}'';
         ExecReload="${pkgs.coreutils}/bin/kill -HUP $MAINPID";

--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -87,7 +87,7 @@ in {
   config = mkIf cfg.enable {
     systemd.services.collectd = {
       description = "Collectd Monitoring Agent";
-      after = [ "network.target" ];
+      after = [ "network-interfaces.target" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {


### PR DESCRIPTION
Also fix network dependency for sensu and telegraf.

Add port-based monitoring for PostgreSQL so we notice when it fails to bind
to a required address.

Fixes #28242

@flyingcircusio/release-managers

Impact:

* PostreSQL will be restarted to activate the changes.

Changelog:

* Ensure correct networking dependencies for PostgreSQL during restarts.
* Add port-based monitoring to ensure PostgreSQL binds to all configured ports.