### PR TITLE
automatically restart grafana

### DIFF
--- a/nixos/modules/flyingcircus/services/grafana.nix
+++ b/nixos/modules/flyingcircus/services/grafana.nix
@@ -79,6 +79,7 @@ in {
           mapAttrs' (n: v: nameValuePair "GF_${n}" (toString v)) envOptions);
       serviceConfig = {
         ExecStart = mkForce "${cfg.package.bin}/bin/grafana-server -homepath ${cfg.dataDir}";
+        Restart = "always";
       };
       preStart = mkForce ''
         ${pkgs.coreutils}/bin/ln -fs ${cfg.package}/share/grafana/conf ${cfg.dataDir}


### PR DESCRIPTION
re #28290

@flyingcircusio/release-managers

Impact:

Changelog: Automatically restart Grafana when it crashes. (#28290)
