### PR TITLE
use proper signal for nginx logrotate.

### DIFF
--- a/nixos/modules/flyingcircus/roles/nginx.nix
+++ b/nixos/modules/flyingcircus/roles/nginx.nix
@@ -193,7 +193,7 @@ in
             rotate 92
             create 0644 nginx service
             postrotate
-                systemctl reload nginx
+                systemctl kill nginx -s USR1 --kill-who=main
             endscript
         }
     '';


### PR DESCRIPTION
reload does a config reload and restarts workers which is not necessary. Also reload will do a config check in near future which could prevent rotating the logs then.

@flyingcircusio/release-managers

Impact:

Changelog: Do not reload nginx workers during logrotate.
