### PR TITLE
reload nginx instead of restart on config change.

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -108,12 +108,14 @@ in
         chmod 700 ${cfg.stateDir}
         chown -R ${cfg.user}:${cfg.group} ${cfg.stateDir}
         '';
+      # Is nginx is already running with a fixed config file location?
       reload = ''
-        # Force a restart if nginx is not yet using /etc/nginx.conf
-        if systemctl status nginx | grep 'master process' | grep -- '-c /etc/nginx.conf'
+        if systemctl status nginx | \
+          grep -v grep | grep -q 'master process .* -c /etc/nginx.conf'
         then
           ${nginx_} -t && ${nginx_} -s reload
         else
+          echo "config file location changed"
           systemctl restart nginx
         fi
       '';

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -110,12 +110,11 @@ in
         '';
       # Is nginx is already running with a fixed config file location?
       reload = ''
-        if systemctl status nginx | \
-          grep -v grep | grep -q 'master process .* -c /etc/nginx.conf'
+        if ${pkgs.procps}/bin/pgrep -a nginx | grep -Fq 'master process ${nginx_}'
         then
           ${nginx_} -t && ${nginx_} -s reload
         else
-          echo "config file location changed"
+          echo "Binary or parameters changed. Restarting."
           systemctl restart nginx
         fi
       '';


### PR DESCRIPTION
Also fail properly when configcheck fails.

For necessary restarts (like binary change) see #28206

re #28325

@flyingcircusio/release-managers

Impact: NGINX will be restarted.

Changelog: Reload NGINX when the configuration changes (instead of restart) #28325
