### PR TITLE
Fix OpenVPN check: management now listens on IPv6, use an appropriate…

### DIFF
--- a/nixos/modules/flyingcircus/roles/external_net/openvpn.nix
+++ b/nixos/modules/flyingcircus/roles/external_net/openvpn.nix
@@ -90,7 +90,7 @@ let
     set timeout 20
 
     puts "OpenVPN: checking management interface"
-    spawn -noecho ${pkgs.netcat}/bin/nc localhost ${mgmPort}
+    spawn -noecho ${pkgs.netcat-openbsd}/bin/nc localhost ${mgmPort}
 
     exit -onexit {
       puts "OpenVPN CRITICAL"


### PR DESCRIPTION
… netcat.

Fixes #28240

@flyingcircusio/release-managers

Impact:

Changelog:

* Fixes broken OpenVPN check since 2.4 update. OpenVPN now listens on IPv6 (only) on the management port and our netcat was IPv4 only. Updated the check to use a proper dual-stack netcat.