### PR TITLE
allow access to prometheus UI via browser

### DIFF
--- a/nixos/modules/flyingcircus/roles/statshost.nix
+++ b/nixos/modules/flyingcircus/roles/statshost.nix
@@ -296,8 +296,15 @@ in
               root /tmp/letsencrypt;
             }
 
-            location / {
+            location = / {
                 rewrite ^ /grafana/ redirect;
+            }
+
+            location / {
+                # Allow access to prometheus
+                auth_basic "FCIO user";
+                auth_basic_user_file "/etc/local/nginx/htpasswd_fcio_users";
+                proxy_pass http://${prometheusListenAddress};
             }
 
             location /grafana/ {


### PR DESCRIPTION
This is handy to see targets etc.

@flyingcircusio/release-managers

Impact:

Changelog: Statshost: Allow direct access to the Prometheus UI.