### PR TITLE
Enable SNMP for Telegraf.

### DIFF
--- a/nixos/modules/flyingcircus/packages/telegraf/default.nix
+++ b/nixos/modules/flyingcircus/packages/telegraf/default.nix
@@ -3,8 +3,8 @@
 
 buildGoPackage rec {
   name = "telegraf-${version}";
-  version = "1.3.1";
-  rev = "f93615672b02a41d9bc867bd92bf31c1d777989b";
+  version = "1.3.5";
+  rev = "7192e68b2423997177692834f53cdf171aee1a88";
 
   goPackagePath = "github.com/influxdata/telegraf";
   excludedPackages = "test";
@@ -12,7 +12,7 @@ buildGoPackage rec {
   src = fetchgit {
     inherit rev;
     url = "https://github.com/influxdata/telegraf";
-    sha256 = "0aq001ck07xarqsj2jv87qmad8bf9s0jzf12jrcny829625r10mw";
+    sha256 = "087fq6ycdbrfrngg8rvalf1kd3n70zkinmjlsv10b7gmprvmh573";
   };
 
   goDeps = ./deps.nix;

--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -294,7 +294,7 @@ in
       };
 
       systemd.timers.graylog-update-geolite = {
-        description = "Timer for updading the geolite db for graylog";
+        description = "Timer for updating the geolite db for graylog";
         wantedBy = [ "timers.target" ];
         timerConfig = {
           Unit = "graylog-update-geolite.service";

--- a/nixos/modules/flyingcircus/roles/statshost.nix
+++ b/nixos/modules/flyingcircus/roles/statshost.nix
@@ -366,7 +366,7 @@ in
       };
 
       systemd.timers.fc-grafana-load-dashboards = {
-        description = "Timer for updading the grafana dashboards";
+        description = "Timer for updating the grafana dashboards";
         wantedBy = [ "timers.target" ];
         timerConfig = {
           Unit = "fc-grafana-load-dashboards.service";

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -232,7 +232,6 @@ in {
 
     systemd.services.sensu-client = {
       wantedBy = [ "multi-user.target" ];
-      requires = [ "network-interfaces.target" ];
       after = [ "network-interfaces.target" ];
 
       path = [

--- a/nixos/modules/flyingcircus/services/telegraf.nix
+++ b/nixos/modules/flyingcircus/services/telegraf.nix
@@ -65,6 +65,7 @@ in {
       description = "Telegraf Agent";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-interfaces.target" ];
+      path = [ pkgs.net_snmp ];
       serviceConfig = {
         ExecStart=''${cfg.package}/bin/telegraf ${startupOptions}'';
         ExecReload="${pkgs.coreutils}/bin/kill -HUP $MAINPID";


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

* Telegraf will be restarted.

Changelog:

* Enable SNMP for Telegraf. This includes an update to a recent Telegraf bugfix release (1.3.1->1.3.5).