### PR TITLE
Exclude JAR and WAR files from userscan

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcuserscan.nix
+++ b/nixos/modules/flyingcircus/packages/fcuserscan.nix
@@ -4,13 +4,13 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "fc-userscan-${version}";
-  version = "0.2.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "userscan";
     rev = version;
-    sha256 = "0gv4fqbv52yy3mkdvbbiv9ldfbs0238sh8hkh10rh3sy0rwl59ac";
+    sha256 = "1qb1z1gvmjwslany2134rlg8fhn3f62ivry0hqqw2bf6ydqvlqv1";
   };
 
   cargoDepsSha256 = "0ddzxyn2ykmflxc4hw11vn7b7nk9l7bi83l4idx1m3qz0ywydcqc";

--- a/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
+++ b/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
@@ -25,8 +25,8 @@ let
     failed=0
     while read user home; do
       sudo -u $user -H -- \
-        fc-userscan -v -S -s 1 -c $home/.cache/fc-userscan.cache \
-        -z '*.egg,*.jar,*.war' -E ${./userscan.exclude} \
+        fc-userscan -v -S -s 2 -c $home/.cache/fc-userscan.cache \
+        -z '*.egg' -E ${./userscan.exclude} \
         $home || failed=1
     done < <(getent passwd | awk -F: '$4 == ${humanGid} || $4 == ${serviceGid} \
               { print $1 " " $6 }')

--- a/nixos/modules/flyingcircus/platform/garbagecollect/userscan.exclude
+++ b/nixos/modules/flyingcircus/platform/garbagecollect/userscan.exclude
@@ -8,6 +8,7 @@ Data.fs
 Data.fs.tmp
 *.deb
 diagnostic.data/metrics.*
+*.diff
 *.doc
 *.docx
 elasticsearch/data/
@@ -24,12 +25,14 @@ graylog/data/
 *.html
 *.icc
 influxdb/data/
+*.jar
 journal/
 *.jpeg
 *.jpg
 *.JPG
 *.kml
 *.kmz
+*.lock
 *.log
 *.log-????????
 *.log.?
@@ -45,6 +48,7 @@ mysql/*/*.{MYD,MYI,frm,ibd}
 *.odt
 *.ogg
 *.otf
+*.patch
 *.pcl
 *.pdf
 *.pdf
@@ -70,6 +74,7 @@ solr/data/
 *.tiff
 *.ttf
 *.vcl
+*.war
 *.wav
 *.webm
 *.xlf


### PR DESCRIPTION
The ZIP lib used is not particularly efficient when it comes to large
archives or archives containing many files. I've excluded JAR and WAR
files as a workaround. In typical Java workflows, those files are
compiled elsewhere and shipped to the target system, so they won't
contain live store references.

In case of local Java code compilation, I'd expect *.class files to
appear. These will be scanned independently.

Re #27553

@flyingcircusio/release-managers

Impact:

Changelog: - 
