### PR TITLE
Only relabel mysql_commands if it was not already relabeled.

### DIFF
--- a/nixos/modules/flyingcircus/roles/mysql.nix
+++ b/nixos/modules/flyingcircus/roles/mysql.nix
@@ -295,8 +295,9 @@ in
   {
     flyingcircus.roles.statshost.prometheusMetricRelabel = [
       {
-        source_labels = [ "__name__" ];
-        regex = "(mysql_commands)_(.+)";
+        source_labels = [ "__name__" "command" ];
+        # Only if there is no command set.
+        regex = "(mysql_commands)_(.+);$";
         replacement = "\${2}";
         target_label = "command";
       }


### PR DESCRIPTION
This happens in multi-rg/federated setups and yields "sample with repeated timestamp but different value" errors.

@flyingcircusio/release-managers

Impact:

Changelog: Fix relabelling of MySQL commands metric in federated Prometheus setups.