### PR TITLE
Update PHP 5.5, 5.6 and 7.0 to most recent bugfix releases.

### DIFF
--- a/nixos/modules/flyingcircus/packages/php/default.nix
+++ b/nixos/modules/flyingcircus/packages/php/default.nix
@@ -285,18 +285,18 @@ let
 in {
 
   php55 = generic {
-    version = "5.5.37";
-    sha256 = "122xj115fjl6rqlxqqjzvh16fbm801yqcmfh9hn7zwfa8sz0wf6j";
+    version = "5.5.38";
+    sha256 = "0f1y76whg6yx9a18mh97f8yq8lb64ri1f0zfr9la9374nbmq2g27";
   };
 
   php56 = generic {
-    version = "5.6.30";
-    sha256 = "01krq8r9xglq59x376zlg261yikckq179jmhnlcg3gqxza9w41d1";
+    version = "5.6.31";
+    sha256 = "03xixkvfp64bqp97p8vlj3hp63bpjw7hc16b7fgm7w35rdlp2fcg";
   };
 
   php70 = generic {
-    version = "7.0.21";
-    sha256 = "07r3qqyyvf16k4xk5b2070fwilggmph5937drjm8cvyyjb1k789b";
+    version = "7.0.24";
+    sha256 = "06fgpljz6xpxxkpf4cv9rqz8g504l9ikbw5aq0hqh5sgd611kycv";
   };
 
 }


### PR DESCRIPTION
Fixes #28594 (security update for PHP 5.6.30 -> 5.6.31)

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for PHP 5.6. (#28594)
* Bugfix updates for PHP 5.6 and 7.0
