### PR TITLE
Update NixOS Linux VM kernel: 4.4.59 -> 4.4.91

### DIFF
--- a/nixos/modules/flyingcircus/packages/kernel/linux-4.4.nix
+++ b/nixos/modules/flyingcircus/packages/kernel/linux-4.4.nix
@@ -3,12 +3,12 @@
 let
   kernel = import ../../../../../pkgs/os-specific/linux/kernel/generic.nix
     (args // rec {
-      version = "4.4.59";
+      version = "4.4.91";
       extraMeta.branch = "4.4";
 
       src = fetchurl {
         url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-        sha256 = "1jlnm6msxdhm7l6all91rd1rkqsqpd0rblbdl68z7nkz9hy55sb4";
+        sha256 = "1ysg4ly5qp65hc79s8pwh1yg7xf9ki16azdwwm6l2n7y3a62p7fb";
       };
 
       kernelPatches = args.kernelPatches;


### PR DESCRIPTION
This includes a wide variety of stability fixes. Most specifically this fixes
a recurring NFS server crash that we have seen occasionally.

Fixes #28503

@flyingcircusio/release-managers

Impact:

* Requires a restart of all VMs.

Changelog:

* Update Linux kernel from 4.4.59 -> 4.4.91. (Fixes #28503)