### PR TITLE
Security update for curl: 7.52.1 -> 7.56.0

### DIFF
--- a/nixos/modules/flyingcircus/packages/curl/default.nix
+++ b/nixos/modules/flyingcircus/packages/curl/default.nix
@@ -16,11 +16,11 @@ assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.52.1";
+  name = "curl-7.56.0";
 
   src = fetchurl {
-    url = "http://curl.haxx.se/download/${name}.tar.bz2";
-    sha256 = "16rqhyzlpnivifin8n7l2fr9ihay9v2nw2drsniinb6bcykqaqfi";
+    url = "http://downloads.fcio.net/packages/${name}.tar.gz";
+    sha256 = "0131a9sm1c48nc52fsl2jp7maamppmnhlx99826vsbb6wnkigg7i";
   };
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -57,8 +57,8 @@ stdenv.mkDerivation ({
          patch extends the search path by "/run/current-system/sw/bin". */
       ./fix_path_attribute_in_getconf.patch
 
-      ./security-4a28f4d5.patch
-      ./security-bdf1ff05.patch
+      ./security-4a28f4d5.patch # cve-2015-8984
+      ./security-bdf1ff05.patch # cve-2015-8983
       ./cve-2014-8121.patch
       ./cve-2015-1781.patch
       ./cve-2015-7547.patch


### PR DESCRIPTION
Fixes #27729

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for curl: 7.52.1 -> 7.56.0 (#27729)