### PR TITLE
Security updates for libxml and libxslt.

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -6,11 +6,11 @@ assert pythonSupport -> python != null;
 
 stdenv.mkDerivation (rec {
   name = "libxml2-${version}";
-  version = "2.9.4";
+  version = "2.9.6";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${name}.tar.gz";
-    sha256 = "0g336cr0bw6dax1q48bblphmchgihx9p1pjmxdnrd6sh3qci3fgz";
+    sha256 = "1g7byn6y0yw17rl74gs89xnxrpwj424938rf8qfqh3i4lz63i44b";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, fetchpatch, libxml2, findXMLCatalogs }:
 
 stdenv.mkDerivation rec {
-  name = "libxslt-1.1.29";
+  name = "libxslt-1.1.31";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${name}.tar.gz";
-    sha256 = "1klh81xbm9ppzgqk339097i39b7fnpmlj8lzn8bpczl3aww6x5xm";
+    sha256 = "1ddh81xbm9ppzgqk339097i39b7fnpmlj8lzn8bpczl3aww6x5xm";
   };
 
   patches = stdenv.lib.optional stdenv.isSunOS ./patch-ah.patch;


### PR DESCRIPTION
libxml: 2.9.4 -> 2.9.6
libxslt: 1.1.29 -> 1.1.31

Fixes #28608
Fixes #28609

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for libxml: 2.9.4 -> 2.9.6 (#28608)
* Security update for libxslt: 1.1.29 -> 1.1.31 (#28609)