### PR TITLE
Fix #28876: always restart telegraf immediately

### DIFF
--- a/nixos/modules/flyingcircus/services/telegraf.nix
+++ b/nixos/modules/flyingcircus/services/telegraf.nix
@@ -58,7 +58,6 @@ in {
     };
   };
 
-
   ###### implementation
   config = mkIf config.services.telegraf.enable {
     systemd.services.telegraf = {
@@ -70,7 +69,7 @@ in {
         ExecStart=''${cfg.package}/bin/telegraf ${startupOptions}'';
         ExecReload="${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         User = "telegraf";
-        Restart = "on-failure";
+        Restart = "always";
       };
     };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog:

* Always restart Telegraf immediately after a crash. This will result in less noise in monitoring and alerting. #28876 
