### PR TITLE
Security update for git: 2.7.4 -> 2.14.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "2.7.4";
+  version = "2.14.2";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "0ys55v2xrhzj74jrrqx75xpr458klnyxshh8d8swfpp0zgg79rfy";
+    sha256 = "18f70gfzwqd210806hmf94blcd7yv5h9ka6xqkpd2jhijqwp5sah";
   };
 
   patches = [


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for git: 2.7.4 -> 2.14.2. #28729 