### PR TITLE
Update Nginx to 0.10.3

### DIFF
--- a/nixos/modules/flyingcircus/packages/nginx/stable.nix
+++ b/nixos/modules/flyingcircus/packages/nginx/stable.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "1.10.2";
-  sha256 = "1hk5szkwns6s0xsvd0aiy392sqbvk3wdl480bpxf55m3hx4sqi8h";
+  version = "1.10.3";
+  sha256 = "75020f1364cac459cb733c4e1caed2d00376e40ea05588fb8793076a4c69dd90";
 })


### PR DESCRIPTION
This PR updates Nginx to latest version of 0.10.x series. 

@flyingcircusio/release-managers

Impact: Nginx will be restarted
