### PR TITLE
Sudo improvements

### DIFF
--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -136,17 +136,15 @@ in
       # Allow unrestricted access to super admins
       %admins ALL=(ALL) PASSWD: ALL
 
-      ## Cmnd alias specification
-      Cmnd_Alias  REBOOT = ${pkgs.systemd}/bin/systemctl reboot, \
-            ${pkgs.systemd}/bin/systemctl poweroff
-
+      # Allow sudo-srv users to become service user.
       %sudo-srv ALL=(%service) ALL
-      %sudo-srv ALL=(root) REBOOT
 
       # Allow applying config and restarting services to service users
       Cmnd_Alias  SYSTEMCTL = ${pkgs.systemd}/bin/systemctl
       %sudo-srv ALL=(root) SYSTEMCTL
       %service  ALL=(root) SYSTEMCTL
+
+
     '';
 
     system.activationScripts.fcio-homedirpermissions = lib.stringAfter [ "users" ]

--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -144,6 +144,10 @@ in
       %sudo-srv ALL=(root) SYSTEMCTL
       %service  ALL=(root) SYSTEMCTL
 
+      # Allow iotop to anaylyze disk io.
+      Cmnd_Alias  IOTOP = ${pkgs.iotop}/bin/iotop
+      %sudo-srv ALL=(root) IOTOP
+      %service  ALL=(root) IOTOP
 
     '';
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: Allow users to run `iotop` via sudo.
