### PR TITLE
Set systemd's retry time for hapoxy to 5s

### DIFF
--- a/nixos/modules/services/networking/haproxy.nix
+++ b/nixos/modules/services/networking/haproxy.nix
@@ -47,6 +47,8 @@ with lib;
         # FCIO ExecStartPre = "${pkgs.haproxy}/sbin/haproxy -c -q -f ${haproxyCfg}";
         ExecStart = "${pkgs.haproxy}/sbin/haproxy -D -f ${haproxyCfg} -p /run/haproxy.pid";
         # FCIO ExecReload = "-${pkgs.bash}/bin/bash -c \"exec ${pkgs.haproxy}/sbin/haproxy -D -f ${haproxyCfg} -p /run/haproxy.pid -sf $MAINPID\"";
+        RestartSec = "5s";
+        StartLimitInterval = "1min";
       };
     };
 


### PR DESCRIPTION
Configure service to retry starting haproxy every 5s for 1 min. 

Re #28920

@flyingcircusio/release-managers

Impact: Service file will be reloaded
