### PR TITLE
Security update for Python 2.7: 2.7.11 -> 2.7.14

### DIFF
--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -22,11 +22,11 @@ with stdenv.lib;
 
 let
   majorVersion = "2.7";
-  version = "${majorVersion}.11";
+  version = "${majorVersion}.14";
 
   src = fetchurl {
     url = "http://www.python.org/ftp/python/${version}/Python-${version}.tar.xz";
-    sha256 = "0iiz844riiznsyhhyy962710pz228gmhv8qi3yk4w4jhmx2lqawn";
+    sha256 = "0rka541ys16jwzcnnvjp2v12m4cwgd2jp6wj4kj511p715pb5zvi";
   };
 
   patches =


### PR DESCRIPTION
Fixes #28607

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for Python 2.7: 2.7.11 -> 2.7.14