### PR TITLE
add docsplit 0.7.6

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -19,6 +19,7 @@ in rec {
 
   boost159 = pkgs.callPackage ./boost/1.59.nix { };
   boost160 = pkgs.callPackage ./boost/1.60.nix { };
+  bundlerApp = pkgs_17_09.bundlerApp;
   busybox = pkgs.callPackage ./busybox { };
 
   cacert = pkgs.callPackage ./cacert.nix { };
@@ -42,6 +43,7 @@ in rec {
   };
 
   dnsmasq = pkgs.callPackage ./dnsmasq.nix { };
+  docsplit = pkgs.callPackage ./docsplit { };
 
   easyrsa3 = pkgs.callPackage ./easyrsa { };
   elasticsearch = pkgs.callPackage ./elasticsearch { };
@@ -57,6 +59,7 @@ in rec {
   fcuserscan = pkgs.callPackage ./fcuserscan.nix { } ;
 
   grafana = pkgs_17_09.grafana;
+  graphicsmagick = pkgs_17_09.graphicsmagick;
   graylog = pkgs.callPackage ./graylog.nix { };
 
   http-parser = pkgs.callPackage ./http-parser {

--- a/nixos/modules/flyingcircus/packages/docsplit/Gemfile
+++ b/nixos/modules/flyingcircus/packages/docsplit/Gemfile
@@ -1,0 +1,2 @@
+source 'http://rubygems.org'
+gem 'docsplit', "0.7.6"

--- a/nixos/modules/flyingcircus/packages/docsplit/Gemfile.lock
+++ b/nixos/modules/flyingcircus/packages/docsplit/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    docsplit (0.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docsplit (= 0.7.6)
+
+BUNDLED WITH
+   1.10.6

--- a/nixos/modules/flyingcircus/packages/docsplit/default.nix
+++ b/nixos/modules/flyingcircus/packages/docsplit/default.nix
@@ -1,0 +1,16 @@
+{ lib, bundlerApp, ruby, pkgs, stdenv, ...}:
+bundlerApp {
+  pname = "docsplit";
+  ruby = ruby;
+  gemdir = ./.;
+  exes = [ "docsplit" ];
+
+  meta = with lib; {
+    description = "A command-line utility and Ruby library for splitting apart documents into their component parts";
+    homepage    = https://documentcloud.github.io/docsplit/;
+    license     = licenses.lgpl2;
+    maintainers = with maintainers; [ zagy ];
+    platforms   = platforms.unix;
+  };
+
+}

--- a/nixos/modules/flyingcircus/packages/docsplit/gemset.nix
+++ b/nixos/modules/flyingcircus/packages/docsplit/gemset.nix
@@ -1,0 +1,9 @@
+{
+  "docsplit" = {
+    version = "0.7.6";
+    source = {
+      type = "gem";
+      sha256 = "0qx8sr7klp272zylsnf7bdq77vizxd2bc9ym2vb4mky93nb68k55";
+    };
+  };
+}

--- a/nixos/modules/flyingcircus/packages/docsplit/update.sh
+++ b/nixos/modules/flyingcircus/packages/docsplit/update.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -x
+export NIX_PATH="nixpkgs=$(dirname $0)/../../../../../"
+rm -rf .bundle
+rm -f Gemfile.lock
+rm -rf /tmp/bundix
+nix-shell -p git -p stdenv -p stdenv -p cacert -p bundler -p openssl \
+    -p nix-prefetch-scripts \
+    --command "bundler package --all --no-install --path /tmp/bundix/bundle"
+nix-shell -p bundix -p nix-prefetch-scripts --command bundix

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -1,6 +1,8 @@
 { pkgs, lib, system, hydraJob }:
 
 {
+  docsplit = hydraJob (import ./docsplit.nix { inherit system; });
+
   elasticsearch = hydraJob (import ./elasticsearch.nix { inherit system; });
 
   haproxy = hydraJob (import ./haproxy.nix { inherit system; }) ;

--- a/nixos/modules/flyingcircus/tests/docsplit.nix
+++ b/nixos/modules/flyingcircus/tests/docsplit.nix
@@ -1,0 +1,26 @@
+import ../../../tests/make-test.nix ({ pkgs, ... }:
+{
+  name = "docsplit";
+
+  nodes = {
+    srv1 =
+      { pkgs, config, ... }:
+      {
+        imports = [
+          ./setup.nix
+          ../static
+          ../roles
+          ../services
+          ../platform
+        ];
+
+      };
+  };
+
+  testScript = ''
+    startAll;
+    $srv1->succeed(<<'__SHELL__');
+    ${pkgs.docsplit}/bin/docsplit --help
+    __SHELL__
+  '';
+})


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: Provide docsplit 0.7.6 package. 


Note: dependencies like libreoffice, pdftk need to be installed separatly via nix-env (or alike)

This is for quaive.
