### PR TITLE
Fix loghost-relay error/access log 

### DIFF
--- a/nixos/modules/flyingcircus/roles/nginx.nix
+++ b/nixos/modules/flyingcircus/roles/nginx.nix
@@ -188,6 +188,7 @@ in
 
     services.logrotate.config = ''
         /var/log/nginx/*access*log
+        /var/log/nginx/*error*log
         /var/log/nginx/performance.log
         {
             rotate 92

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -368,7 +368,8 @@ in
       flyingcircus.roles.nginx.httpConfig = ''
         server {
           listen ${prometheusListenAddress};
-          error_log /tmp/error.log debug;
+          access_log /var/log/nginx/loghost_access.log;
+          error_log /var/log/nginx/loghost_error.log;
 
           location = /scrapeconfig.json {
             alias /etc/local/statshost/scrape-rg.json;


### PR DESCRIPTION

@flyingcircusio/release-managers

Impact:

Changelog:  For the loghost-relay, provide a separate access log (``/var/log/nginx/loghost_access.log``), and a separate error log (``/var/log/nginx/loghost_error.log``)
