### PR TITLE
Ignore fc-collect-garbage fails in unit check.

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -309,7 +309,7 @@ in {
       };
       systemd_units = {
         notification = "systemd has failed units";
-        command = "check-failed-units.rb -m logrotate.service";
+        command = "check-failed-units.rb -m logrotate.service -m fc-collect-garbage.service";
       };
       disk = {
         notification = "Disk usage too high";


### PR DESCRIPTION
The unit check is mostly meant for units with customer-impact, which this is not. Besides, there is another check on the the stamp file.

@flyingcircusio/release-managers

Impact:

Changelog: Ignore fc-collect-garbage fails in Sensu monitoring. 