### PR TITLE
Varnish: Depend on network.target to prevent startup errors Re #28908

### DIFF
--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -42,6 +42,7 @@ with lib;
     systemd.services.varnish = {
       description = "Varnish";
       wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
       preStart = ''
         mkdir -p ${cfg.stateDir}
         chown -R varnish:varnish ${cfg.stateDir}


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:
* service file will be reloaded

Changelog:
* varnish service waits for network to be up
