### PR TITLE
Reintroduce circular dependency test

### DIFF
--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -5,15 +5,15 @@
 
   elasticsearch = hydraJob (import ./elasticsearch.nix { inherit system; });
 
-  haproxy = hydraJob (import ./haproxy.nix { inherit system; }) ;
+  haproxy = hydraJob (import ./haproxy.nix { inherit system; });
 
-  login = hydraJob (import ./login.nix { inherit system; }) ;
+  login = hydraJob (import ./login.nix { inherit system; });
 
   mariadb = hydraJob (import ./mariadb.nix { inherit system; });
 
-  memcached = hydraJob (import ./memcached.nix { inherit system; }) ;
+  memcached = hydraJob (import ./memcached.nix { inherit system; });
 
-  mongodb = hydraJob (import ./mongodb { inherit system; }) ;
+  mongodb = hydraJob (import ./mongodb { inherit system; });
 
   inherit (import ./nodejs.nix { inherit system hydraJob; })
     nodejs_4 nodejs_6 nodejs_7;
@@ -41,6 +41,7 @@
   rabbitmq = hydraJob (import ./rabbitmq.nix { inherit system; });
 
   sensuserver = hydraJob (import ./sensu.nix { inherit system; });
+  systemdCycles = hydraJob (import ./systemd_cycles.nix { inherit system; });
 
   users = hydraJob (import ./users { inherit system; });
 }

--- a/nixos/modules/flyingcircus/tests/systemd_cycles.nix
+++ b/nixos/modules/flyingcircus/tests/systemd_cycles.nix
@@ -1,0 +1,28 @@
+import ../../../tests/make-test.nix ({ pkgs, ... }:
+
+# Checks that systemd does not detect any circular service dependencies on boot.
+{
+  name = "systemd_cycles";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ theuni ];
+  };
+
+  nodes = {
+    cycles =
+      { ... }:
+      {
+        imports = [
+          ./setup.nix
+          ../static
+          ../services
+          ../platform
+        ];
+      };
+  };
+
+  testScript = ''
+    $cycles->waitForUnit('multi-user.target');
+    $cycles->waitUntilSucceeds('pgrep -f "agetty.*tty1"');
+    $cycles->fail('journalctl -b | egrep "systemd.*cycle"');
+  '';
+})


### PR DESCRIPTION
This test has been inadvertently deleted from PR #304 while dropping
sysstat completely.

Re #28203

@flyingcircusio/release-managers

Impact:

Changelog: Test for circular systemd service dependencies (#28203)
