### PR TITLE
don't start dogstatd when there is no config set by user

### DIFF
--- a/nixos/modules/flyingcircus/roles/datadog.nix
+++ b/nixos/modules/flyingcircus/roles/datadog.nix
@@ -63,6 +63,7 @@ in
 
     systemd.services.dogstatsd = {
       serviceConfig = lib.mkForce {
+        enable = (localConfig != {});
         ExecStart = "${pkgs.dd-agent}/bin/dogstatsd";
         User = "datadog";
         Group = "datadog";


### PR DESCRIPTION
re #27879

@flyingcircusio/release-managers

Impact:

Changelog: Don't try to start dogstatsd (from datadog role) when there is no configuration for it (#27879)
