### PR TITLE
Update and fix virtualbox guest additions build. Also, this includes …

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -208,6 +208,11 @@ in rec {
     (old: {
       buildFlags = "localstatedir=/var/spool";
     });
+  virtualbox = pkgs_17_09.virtualbox;
+  # The guest additions need to use the kernel we're actually building so we
+  # have to callPackage them instead of using the pre-made package.
+  virtualboxGuestAdditions = pkgs_17_09.callPackage "${pkgs_17_09_src}/pkgs/applications/virtualization/virtualbox/guest-additions" { kernel = linux; };
+
   vulnix = pkgs.callPackage ./vulnix { };
 
   xtrabackup = pkgs.callPackage ./percona/xtrabackup.nix { };


### PR DESCRIPTION
…it in our

tested set so that we notice when it breaks again.

@flyingcircusio/release-managers

Impact:

* Nothing.

Changelog:

* Update and fix VirtualboxGuest additions to build correctly with our VM guest kernel for Vagrant installations.