### PR TITLE
Various tunings to massively speed up our VM image. This switches from

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -87,8 +87,15 @@ in rec {
     kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper ];
   };
   linuxPackages = linuxPackages_4_4;
-  linuxPackages_4_4 = pkgs.recurseIntoAttrs
-    (pkgs.linuxPackagesFor linux_4_4 linuxPackages_4_4);
+  linuxPackages_4_4 = 
+    # This is hacky, but works for now. linuxPackagesFor is intended to
+    # automatically customize for each kernel but making that overridable
+    # is beyond my comprehension right now.
+    let 
+      default_pkgs = pkgs.recurseIntoAttrs
+      (pkgs.linuxPackagesFor linux_4_4 linuxPackages_4_4);
+    in 
+      lib.overrideExisting default_pkgs { inherit virtualbox virtualboxGuestAdditions; };
 
   mc = pkgs.callPackage ./mc.nix { };
   mariadb = pkgs.callPackage ./mariadb.nix { };
@@ -211,8 +218,7 @@ in rec {
   virtualbox = pkgs_17_09.virtualbox;
   # The guest additions need to use the kernel we're actually building so we
   # have to callPackage them instead of using the pre-made package.
-  virtualboxGuestAdditions = pkgs_17_09.callPackage "${pkgs_17_09_src}/pkgs/applications/virtualization/virtualbox/guest-additions" { kernel = linux; };
-
+  virtualboxGuestAdditions = pkgs_17_09.callPackage "${pkgs_17_09_src}/pkgs/applications/virtualization/virtualbox/guest-additions" { kernel = linux_4_4; };
   vulnix = pkgs.callPackage ./vulnix { };
 
   xtrabackup = pkgs.callPackage ./percona/xtrabackup.nix { };

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -210,7 +210,7 @@ rec {
       -nographic -no-reboot \
       -virtfs local,path=/nix/store,security_model=none,mount_tag=store \
       -virtfs local,path=$TMPDIR/xchg,security_model=none,mount_tag=xchg \
-      -drive file=$diskImage,if=virtio,cache=writeback,werror=report \
+      -drive file=$diskImage,if=virtio,cache=unsafe,werror=report \
       -kernel ${kernel}/${img} \
       -initrd ${initrd}/initrd \
       -append "console=ttyS0 panic=1 command=${stage2Init} out=$out mountDisk=$mountDisk loglevel=4" \


### PR DESCRIPTION
bzip2 to lz4 which has been the last insanely slow chunk, but also the
whole copying the store into the VM was extremely slow.

And lastly, fix the reference to the virtualbox guest so it gets correctly
picked upo and ensure it will be also still built on hydra.

@flyingcircusio/release-managers

Impact:

* This will temporarily break our image charging code as we're moving from bzip2 to lz4 for much faster compression.

Changelog:
