### PR TITLE
Disable the systemd service if we disable the agent. This avoids star…

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/vagrant/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/vagrant/default.nix
@@ -35,6 +35,11 @@ in
   # Enable guest additions.
   virtualisation.virtualbox.guest.enable = true;
 
+  # Disable the regular fc-manage agent: this would try to talk to the
+  # directory and perform VM resizes, etc. This won't work on vagrant, so we
+  # disable it.
+  flyingcircus.agent.enable = false;
+
   # Creates a "vagrant" users with password-less sudo access
   users.extraGroups = [
     { name = "admins"; }


### PR DESCRIPTION
…ting the

agent initially upon boot in Vagrant VMs by suppressing the agent there
in general.

@flyingcircusio/release-managers

Impact:

-

Changelog:

- Disable the fc-manage service on Vagrant completely.