### PR TITLE
vulnix: 1.3.4 -> 1.4.0

### DIFF
--- a/nixos/modules/flyingcircus/packages/python-packages.nix
+++ b/nixos/modules/flyingcircus/packages/python-packages.nix
@@ -6,7 +6,10 @@
 # version are better off in all-packages.nix.
 { pkgs, stdenv, python, self, buildPythonPackage }:
 
-rec {
+let
+  lib = pkgs.lib;
+
+in rec {
   click = buildPythonPackage {
     name = "click-6.6";
     src = pkgs.fetchurl {
@@ -27,6 +30,25 @@ rec {
     src = ./fcutil;
     doCheck = false;
   };
+
+  # backported from 17.09
+  fetchPypi = lib.makeOverridable( {format ? "setuptools", ... } @attrs:
+    let
+      fetchWheel = {pname, version, sha256, python ? "py2.py3", abi ? "none", platform ? "any"}:
+      # Fetch a wheel. By default we fetch an universal wheel.
+      # See https://www.python.org/dev/peps/pep-0427/#file-name-convention for details regarding the optional arguments.
+        let
+          url = "https://files.pythonhosted.org/packages/${python}/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}-${python}-${abi}-${platform}.whl";
+        in pkgs.fetchurl {inherit url sha256;};
+      fetchSource = {pname, version, sha256, extension ? "tar.gz"}:
+      # Fetch a source tarball.
+        let
+          url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.${extension}";
+        in pkgs.fetchurl {inherit url sha256;};
+      fetcher = (if format == "wheel" then fetchWheel
+        else if format == "setuptools" then fetchSource
+        else throw "Unsupported kind ${format}");
+    in fetcher (builtins.removeAttrs attrs ["format"]) );
 
   freezegun = buildPythonPackage rec {
     name = "freezegun-${version}";

--- a/nixos/modules/flyingcircus/packages/vulnix/default.nix
+++ b/nixos/modules/flyingcircus/packages/vulnix/default.nix
@@ -1,17 +1,18 @@
-{ pkgs, fetchurl }:
+{ pkgs, fetchurl, python3Packages }:
 
 let
+  pname = "vulnix";
+  version = "1.4.0";
   python = import ./requirements.nix { inherit pkgs; };
-  version = "1.3.3";
-  src = fetchurl {
-    url = https://pypi.python.org/packages/b8/11/16478573b2f341b84fb6357785511d33551f4515ef6c3661a79cf04da786/vulnix-1.3.3.tar.gz;
-    sha256 = "1fhlgvp78np8i2wab6q6ypgl1bd4d1vlvip4j51fs8226qpyd7y2";
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "19kfqxlrigrgwn74x06m70ar2fhyhic5kfmdanjwjcbaxblha3l8";
   };
 
 in
 python.mkDerivation {
   inherit version src;
-  name = "vulnix-${version}";
+  name = "${pname}-${version}";
 
   buildInputs = [
     python.packages."flake8"

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -332,4 +332,12 @@ rec {
     ftp://ftp.halifax.rwth-aachen.de/pub/OpenBSD/
     ftp://mirror.switch.ch/pub/OpenBSD/
   ];
+
+  # Python PyPI mirrors
+  pypi = [
+    https://files.pythonhosted.org/packages/source/
+    # pypi.io is a more semantic link, but atm it’s referencing
+    # files.pythonhosted.org over two redirects
+    https://pypi.io/packages/source/
+  ];
 }


### PR DESCRIPTION
The new vulnix version contains auto-detection of CVE patches. This is
expected to cut false positives significantly.

Also backport `fetchPypi` helper from 17.09.

@flyingcircusio/release-managers

Impact:

Changelog: Update vulnix to 1.4.0
