### PR TITLE
update to grafana 4.6.2

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -58,7 +58,7 @@ in rec {
   fcsensuplugins = pkgs.callPackage ./fcsensuplugins { };
   fcuserscan = pkgs.callPackage ./fcuserscan.nix { } ;
 
-  grafana = pkgs_17_09.grafana;
+  grafana = pkgs_17_09.callPackage ./grafana { };
   graphicsmagick = pkgs_17_09.graphicsmagick;
   graylog = pkgs.callPackage ./graylog.nix { };
 

--- a/nixos/modules/flyingcircus/packages/grafana/default.nix
+++ b/nixos/modules/flyingcircus/packages/grafana/default.nix
@@ -1,0 +1,36 @@
+# copied from master
+{ lib, buildGoPackage, fetchurl, fetchFromGitHub, phantomjs2 }:
+
+buildGoPackage rec {
+  version = "4.6.2";
+  name = "grafana-v${version}";
+  goPackagePath = "github.com/grafana/grafana";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "grafana";
+    sha256 = "0awf00n3rrxjyiza3mga496k1k9c4fkg6rxn9azdab1qvdkzh513";
+  };
+
+  srcStatic = fetchurl {
+    url = "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${version}.linux-x64.tar.gz";
+    sha256 = "08svlg190h5nvv701lcl3a2iak2xdmslpdwjv2w5fcdfyp7bd6ld";
+  };
+
+  preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";
+  postInstall = ''
+    tar -xvf $srcStatic
+    mkdir -p $bin/share/grafana
+    mv grafana-*/{public,conf,vendor} $bin/share/grafana/
+    ln -sf ${phantomjs2}/bin/phantomjs $bin/share/grafana/vendor/phantomjs/phantomjs
+  '';
+
+  meta = with lib; {
+    description = "Gorgeous metric viz, dashboards & editors for Graphite, InfluxDB & OpenTSDB";
+    license = licenses.asl20;
+    homepage = https://grafana.org/;
+    maintainers = with maintainers; [ offline fpletz willibutz ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
re #29125

@flyingcircusio/release-managers

Impact:

Changelog: Update to Grafana 4.6.2 (statshost role). This version of Grafana includes annotations, which nicely allow to note events in the dashboards. (#29125)
