### PR TITLE
Make loghost scalable

### DIFF
--- a/nixos/modules/flyingcircus/lib/utils.nix
+++ b/nixos/modules/flyingcircus/lib/utils.nix
@@ -1,4 +1,31 @@
 { lib }:
-{
+with lib;
+rec {
+
+  # get the DN of this node for LDAP logins.
+  getLdapNodeDN = config:
+    "cn=${config.networking.hostName},ou=Nodes,dc=gocept,dc=com";
+
+  # Compute LDAP password for this node.
+  getLdapNodePassword = config:
+    builtins.hashString "sha256" (concatStringsSep "/" [
+      "ldap"
+      config.flyingcircus.enc.parameters.directory_password
+      config.networking.hostName
+    ]);
+
+  listServiceAddresses = config: service:
+    (map
+      (service: service.address)
+      (filter
+        (s: s.service == service)
+        config.flyingcircus.enc_services));
+
+  listServiceAddressesWithPort = config: service: port:
+    map
+      (address: "${address}:${toString port}")
+      (listServiceAddresses config service);
+
   mkPlatform = lib.mkOverride 900;
+
 }

--- a/nixos/modules/flyingcircus/roles/default.nix
+++ b/nixos/modules/flyingcircus/roles/default.nix
@@ -21,6 +21,7 @@ in
      ./elasticsearch.nix
      ./external_net
      ./generic.nix
+     ./graylog.nix
      ./haproxy.nix
      ./java.nix
      ./loghost.nix

--- a/nixos/modules/flyingcircus/roles/graylog.nix
+++ b/nixos/modules/flyingcircus/roles/graylog.nix
@@ -1,0 +1,584 @@
+# NOTES:
+# * Mongo cluster setup requires manual intervention.
+
+
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.flyingcircus.roles.graylog;
+  fclib = import ../lib;
+
+  listenOn = "${config.flyingcircus.enc.name}.${config.networking.domain}";
+  serviceUser = "graylog";
+
+
+  # XXX it helps a lot if the admin password is the same on all nodes. Hence
+  # we should generate it somehow. But how?!
+  # -- files --
+  rootPasswordFile = "/etc/local/graylog/password";
+  passwordSecretFile = "/etc/local/graylog/password_secret";
+  # -- passwords --
+  generatedRootPassword = mkPassword "graylog.rootPassword";
+  generatedPasswordSecret = mkPassword "graylog.passwordSecret";
+
+  rootPassword = removeSuffix "\n"
+    (if cfg.rootPassword  == null
+    then (fclib.configFromFile
+            rootPasswordFile
+            generatedRootPassword)
+    else cfg.rootPassword);
+
+  rootPasswordSha2 = mkSha2 rootPassword;
+
+  passwordSecret =
+    if cfg.passwordSecret == null
+    then (fclib.configFromFile
+            passwordSecretFile
+            generatedPasswordSecret)
+    else cfg.passwordSecret;
+
+
+  glAPIPort = 9001;
+  glAPIHAPort = 8002;
+  gelfTCPHAPort = 12201;
+  gelfTCPGraylogPort = 12202;
+
+  webListenPath = "/";
+  webListenUri = "http://${listenOn}:${toString glAPIPort}${webListenPath}";
+  restListenUri = "http://${listenOn}:${toString glAPIPort}/api";
+
+  # -- helper functions --
+  passwordActivation = file: password: user:
+    let script = ''
+     install -d -o ${toString config.ids.uids."${user}"} -g service -m 02775 \
+        $(dirname ${file})
+      if [[ ! -e ${file} ]]; then
+        ( umask 007;
+          echo ${password} > ${file}
+          chown ${user}:service ${file}
+        )
+      fi
+      chmod 0660 ${file}
+    '';
+    in script;
+
+  mkPassword = identifier:
+    removeSuffix "\n" (readFile
+      (pkgs.runCommand identifier { preferLocalBuild = true; }
+        "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out")
+      );
+
+  mkSha2 = text:
+    removeSuffix "\n" (readFile
+    (pkgs.runCommand "mkSha2" {
+      inherit text;
+      passAsFile = [ "text" ];
+    } "sha256sum < $textPath | cut -f1 -d \" \" > $out"));
+
+  logstashSSLHelper = with pkgs; writeScriptBin "logstash_ssl_import" ''
+    #!${stdenv.shell}
+    set -eu
+
+    puppet="puppet.$FCIO_LOCATION.gocept.net"
+    pw=$(${pwgen}/bin/pwgen -1 18)
+
+    scp $puppet:/var/lib/puppet/lumberjack/keys/$FCIO_HOSTNAME.{crt,key} /var/lib/graylog/
+    (cd /var/lib/graylog
+     ${openssl}/bin/openssl pkcs12 -export -in $FCIO_HOSTNAME.crt \
+                 -inkey $FCIO_HOSTNAME.key \
+                 -out $FCIO_HOSTNAME.p12 \
+                 -name $FCIO_HOSTNAME \
+                 -passin pass:$pw \
+                 -passout pass:$pw
+     rm -f $FCIO_HOSTNAME.jks
+     ${openjdk}/bin/keytool -importkeystore \
+                 -srckeystore $FCIO_HOSTNAME.p12 \
+                 -srcstoretype PKCS12\
+                 -srcstorepass $pw \
+                 -alias $FCIO_HOSTNAME \
+                 -deststorepass $pw \
+                 -destkeypass $pw \
+                 -destkeystore $FCIO_HOSTNAME.jks
+                 )
+    echo "keystore: /var/lib/graylog/$FCIO_HOSTNAME.jks"
+    echo "password: $pw"
+  '';
+
+  glNodes =
+    fclib.listServiceAddresses config "loghost-server" ++
+    fclib.listServiceAddresses config "graylog-server";
+
+  esNodes =
+    (map
+      (address: "${address}:9350")
+      glNodes)
+    ++
+      fclib.listServiceAddressesWithPort config "elasticsearch-node" 9300;
+
+  replSetName = if cfg.cluster then "graylog" else "";
+
+  isMaster =
+    (head glNodes)
+    == "${config.networking.hostName}.${config.networking.domain}";
+
+in
+{
+
+  options = {
+
+    flyingcircus.roles.graylog = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the Graylog role.
+
+          Note: there can be multiple graylogs per RG, unlike loghost.
+        '';
+      };
+
+      cluster = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Build a GL cluster. Ususally disabled by loghost role.";
+      };
+
+      rootPassword = mkOption {
+        type = types.nullOr types.string;
+        default = null;
+        description = ''
+          The password for of your graylogs's webui root user. If null, a random password will be generated.
+        '';
+      };
+
+      passwordSecret = mkOption {
+        type = types.nullOr types.string;
+        default = null;
+        description = ''
+          A password secret for graylog. Use the same password secret fo the whole graylog
+          cluster. If null, a random password will be generated.
+        '';
+      };
+
+      heapPercentage = mkOption {
+        type = types.int;
+        default = 70;
+        description = "How much RAM should go to graylog heap.";
+      };
+
+      esNodes = mkOption {
+        type = types.listOf types.string;
+        default = esNodes;
+        description = "List of elasticsearch nodes";
+      };
+
+      syslogInputPort = mkOption {
+        type = types.int;
+        default = 5140;
+        description = "UDP Port for the Graylog syslog input.";
+      };
+
+      publicFrontend = {
+
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Configure Nginx for GL UI on FE at 80/443?";
+        };
+
+        ssl = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable SSL. This is disabled initially to be able to provide a cert
+            via Let's Encrypt.
+
+            It epects
+
+            * /etc/local/nginx/graylog.crt, and
+            * /etc/local/nginx/graylog.key
+
+            to be present.
+
+          '';
+        };
+
+        hostName = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "HTTP host name for the GL frontend.";
+          example = "graylog.example.com";
+        };
+      };
+
+    };
+  };
+
+  config = mkMerge [
+
+    (mkIf cfg.enable {
+      environment.systemPackages = [ logstashSSLHelper ];
+
+
+      networking.firewall.allowedTCPPorts = [ 9000 9002 ];
+
+      flyingcircus.roles.nginx.enable = true;
+      flyingcircus.roles.nginx.httpConfig =
+      let
+        listenOnPort = interface: port:
+          lib.concatMapStringsSep "\n    "
+              (addr: "listen ${addr}:${toString port};")
+              (fclib.listenAddressesQuotedV6 config interface);
+        allow = ips: lib.concatMapStringsSep "\n    "
+            (addr: "allow ${addr};")
+            (ips);
+      in ''
+        # Direct access w/o prior authentication. This is useful for API access.
+        # Strip Remote-User as there is nothing in between the user and us.
+        server {
+            ${listenOnPort "ethsrv" 9002}
+
+            location / {
+                proxy_set_header Remote-User "";
+                proxy_set_header X-Graylog-Server-URL http://${config.networking.hostName}.${config.networking.domain}:9002/api;
+                proxy_pass http://${listenOn}:${toString glAPIHAPort};
+            }
+
+          }
+
+      '' + optionalString (cfg.publicFrontend.enable && !cfg.publicFrontend.ssl) ''
+        # Frontend FE interface at 80/443
+        server {
+          ${listenOnPort "ethfe" 80}
+          server_name ${cfg.publicFrontend.hostName};
+
+          location /.well-known {
+              root /tmp/letsencrypt;
+          }
+
+          location / {
+              proxy_set_header Remote-User "";
+              proxy_set_header X-Graylog-Server-URL http://${cfg.publicFrontend.hostName}:80/api;
+              proxy_pass http://${listenOn}:${toString glAPIHAPort};
+          }
+
+        }
+      '' + optionalString (cfg.publicFrontend.enable && cfg.publicFrontend.ssl) ''
+        server {
+          ${listenOnPort "ethfe" 80}
+          server_name ${cfg.publicFrontend.hostName};
+
+          location /.well-known {
+              root /tmp/letsencrypt;
+          }
+
+          location = / {
+              rewrite ^ https://$server_name$request_uri redirect;
+          }
+        }
+
+        server {
+          ${listenOnPort "ethfe" "443 ssl http2"}
+          server_name ${cfg.publicFrontend.hostName};
+
+          ssl_certificate ${/etc/local/nginx/graylog.crt};
+          ssl_certificate_key ${/etc/local/nginx/graylog.key};
+
+          location / {
+              proxy_set_header Remote-User "";
+              proxy_set_header X-Graylog-Server-URL https://${cfg.publicFrontend.hostName}:443/api;
+              proxy_pass http://${listenOn}:${toString glAPIHAPort};
+          }
+        }
+
+      '';
+
+      system.activationScripts.fcio-loghost =
+        stringAfter
+          [ ]
+          (passwordActivation rootPasswordFile rootPassword serviceUser +
+           passwordActivation passwordSecretFile passwordSecret serviceUser);
+
+      services.graylog = {
+        enable = true;
+        elasticsearchClusterName = "graylog";
+        inherit passwordSecret rootPasswordSha2 webListenUri restListenUri;
+        elasticsearchDiscoveryZenPingUnicastHosts =
+          concatStringsSep "," cfg.esNodes;
+        javaHeap = ''${toString
+          (fclib.max [
+            ((fclib.current_memory config 1024) * cfg.heapPercentage / 100)
+            768
+            ])}m'';
+        mongodbUri = let
+          repl = if cfg.cluster then "?replicaSet=${replSetName}" else "";
+          mongodbNodes = concatStringsSep ","
+              (map (node: "${node}:27017") glNodes);
+          in
+            "mongodb://${mongodbNodes}/graylog${repl}";
+        isMaster = isMaster;
+        extraConfig = let
+            trustedProxies =
+              concatStringsSep ", " (
+                map
+                  (a: "${fclib.stripNetmask a.ip}/${if fclib.isIp4 a.ip then "32" else "128"}")
+                  (filter
+                    (a: builtins.elem "${a.name}.${config.networking.domain}" glNodes)
+                    config.flyingcircus.enc_addresses.srv));
+          in ''
+            trusted_proxies = ${trustedProxies}
+            processbuffer_processors = ${toString
+              (fclib.max [
+                ((fclib.current_cores config 1) - 2)
+                5])}
+            outputbuffer_processors = ${toString
+              (fclib.max [
+                ((fclib.current_cores config 1) / 2)
+                3])}
+          '';
+      };
+
+      flyingcircus.roles.mongodb32.enable = true;
+      services.mongodb.replSetName = replSetName;
+
+
+      systemd.services.graylog-config = {
+        description = "Configure Graylog FCIO settings";
+        requires = [ "graylog.service" ];
+        after = [ "graylog.service" "mongodb.service" "elasticsearch.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          User = config.services.graylog.user;
+          RemainAfterExit = true;
+        };
+        script = let
+          api = restListenUri;
+          user = "admin";
+          pw = rootPassword;
+
+          syslog_udp_configuration = {
+            configuration = {
+              bind_address = "0.0.0.0";
+              port = cfg.syslogInputPort;
+            };
+            title = "Syslog UDP"; # be careful changing it, it's used as
+                                  # a primary key for identifying the config
+                                  # object
+            type = "org.graylog2.inputs.syslog.udp.SyslogUDPInput";
+            global = true;
+          };
+
+          gelf_tcp_configuration = {
+            configuration = {
+              bind_address = "0.0.0.0";
+              port = gelfTCPGraylogPort;
+            };
+            title = "GELF TCP";
+            type = "org.graylog2.inputs.gelf.tcp.GELFTCPInput";
+            global = true;
+          };
+
+          sso_configuration = {
+            default_group = "Admin";
+            auto_create_user = true;
+            username_header = "Remote-User";
+            fullname_header = "X-Graylog-Fullname";
+            email_header = "X-Graylog-Email";
+            require_trusted_proxies = true;
+            trusted_proxies = "";  # Disable SSO auth
+          };
+
+          geodb_configuration = {
+            enabled = true;
+            db_type = "MAXMIND_CITY";
+            db_path = "/var/lib/graylog/GeoLite2-City.mmdb";
+          };
+
+          ldap_configuration = {
+              enabled = true;
+              system_username = fclib.getLdapNodeDN config;
+              system_password = fclib.getLdapNodePassword config;
+              ldap_uri = "ldaps://ldap.rzob.gocept.net:636/";
+              trust_all_certificates = true;
+              use_start_tls = false;
+              active_directory = false;
+              search_base = "ou=People,dc=gocept,dc=com";
+              search_pattern = "(&(&(objectClass=inetOrgPerson)(uid={0}))(memberOf=cn=${config.flyingcircus.enc.parameters.resource_group},ou=GroupOfNames,dc=gocept,dc=com))";
+              display_name_attribute = "displayName";
+              default_group = "Admin";
+          };
+
+          configure_graylog_raw = what: ''
+            ${pkgs.fcmanage}/bin/fc-graylog \
+              -u '${user}' \
+              -p '${removeSuffix "\n" pw}' \
+              ${what} \
+              '${api}'
+            '';
+          configure_graylog_input = input:
+            configure_graylog_raw "--input '${builtins.toJSON input}'";
+
+          configure_graylog = path: configuration: configure_graylog_raw ''
+              --raw-path ${path} \
+              --raw-data '${builtins.toJSON configuration}' '';
+        in ''
+          ${configure_graylog_input syslog_udp_configuration}
+          ${configure_graylog_input gelf_tcp_configuration}
+
+          ${configure_graylog
+              "/plugins/org.graylog.plugins.auth.sso/config"
+              sso_configuration}
+          ${configure_graylog
+            "/system/cluster_config/org.graylog.plugins.map.config.GeoIpResolverConfig"
+            geodb_configuration}
+          ${configure_graylog
+            "/system/ldap/settings"
+            ldap_configuration}
+        '';
+      };
+
+      systemd.services.graylog-update-geolite = {
+        description = "Update geolite db for graylog";
+        restartIfChanged = false;
+        after = [ "graylog.service" ];
+        serviceConfig = {
+          User = config.services.graylog.user;
+          Type = "oneshot";
+        };
+
+        script = ''
+          cd /var/lib/graylog
+          ${pkgs.curl}/bin/curl -O http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
+          ${pkgs.gzip}/bin/gunzip -f GeoLite2-City.mmdb.gz
+        '';
+      };
+
+      systemd.timers.graylog-update-geolite = {
+        description = "Timer for updating the geolite db for graylog";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          Unit = "graylog-update-geolite.service";
+          OnStartupSec = "10m";
+          OnUnitActiveSec = "30d";
+          # Not yet supported by our systemd version.
+          # RandomSec = "3m";
+        };
+      };
+
+      services.collectd.extraConfig = ''
+        LoadPlugin curl_json
+        <Plugin curl_json>
+          <URL "${restListenUri}/system/journal">
+            User "admin"
+            Password "${rootPassword}"
+            Header "Accept: application/json"
+            Instance "graylog"
+            <Key "uncommitted_journal_entries">
+              Type "gauge"
+            </Key>
+            <Key "append_events_per_second">
+              Type "gauge"
+            </Key>
+            <Key "read_events_per_second">
+              Type "gauge"
+            </Key>
+          </URL>
+          <URL "${restListenUri}/system/throughput">
+            User "admin"
+            Password "${rootPassword}"
+            Header "Accept: application/json"
+            Instance "graylog"
+            <Key "throughput">
+              Type "gauge"
+            </Key>
+          </URL>
+        </Plugin>
+      '';
+
+      flyingcircus.services.sensu-client.checks = {
+        graylog_ui = {
+          notification = "Graylog UI alive";
+          command = ''
+            check_http -H ${listenOn} -p ${toString glAPIPort} \
+              -u ${webListenPath}/
+          '';
+        };
+      };
+
+      # HAProxy load balancer.
+      # Since haproxy is rather lightweight we just fire up one on each graylog
+      # node, talking to all known graylog nodes.
+      flyingcircus.roles.haproxy.enable = true;
+      flyingcircus.roles.haproxy.haConfig = let
+        backendConfig = node_config: concatStringsSep "\n"
+          (map
+            (node: "    " + (node_config node))
+            glNodes);
+        listenConfig = port: concatStringsSep "\n"
+          (map
+            (addr: "    bind ${addr}:${toString port}")
+            (fclib.listenAddresses config "ethsrv"));
+      in ''
+        global
+            daemon
+            chroot /var/empty
+            user haproxy
+            group haproxy
+            maxconn 4096
+            log localhost local2
+            stats socket ${config.flyingcircus.roles.haproxy.statsSocket} mode 660 group nogroup level operator
+
+        defaults
+            mode http
+            log global
+            option httplog
+            option dontlognull
+            option http-keep-alive
+            option redispatch
+
+            timeout connect 5s
+            timeout client 30s    # should be equal to server timeout
+            timeout server 30s    # should be equal to client timeout
+            timeout queue 2
+
+        listen gelf-tcp-in
+        ${listenConfig gelfTCPHAPort}
+            mode tcp
+            default_backend gelf_tcp
+
+        listen graylog_http
+        ${listenConfig glAPIHAPort}
+            use_backend stats if { path_beg /admin/stats }
+            default_backend graylog
+
+        backend gelf_tcp
+            mode tcp
+            balance leastconn
+            option tcplog
+            option httpchk HEAD /api/system/lbstatus
+        ${backendConfig (node:
+            "server ${node}  ${node}:${toString gelfTCPGraylogPort} check port ${toString glAPIPort} inter 10s rise 2 fall 1")}
+
+        backend graylog
+            balance roundrobin
+            option httpchk HEAD /api/system/lbstatus
+        ${backendConfig (node:
+            "server ${node}  ${node}:${toString glAPIPort} check fall 1 rise 2 inter 10s maxconn 20")}
+
+        backend stats
+            stats uri /
+            stats refresh 5s
+      '';
+
+      })
+
+    (mkIf (builtins.length glNodes > 0) {
+      # Forward all syslog to graylog, if there is one in the RG.
+      flyingcircus.syslog.extraRules = ''
+        *.* @${builtins.head glNodes}:${toString cfg.syslogInputPort};RSYSLOG_SyslogProtocol23Format
+      '';
+    })
+  ];
+}

--- a/nixos/modules/flyingcircus/roles/graylog.nix
+++ b/nixos/modules/flyingcircus/roles/graylog.nix
@@ -8,7 +8,7 @@ let
   cfg = config.flyingcircus.roles.graylog;
   fclib = import ../lib;
 
-  listenOn = "${config.flyingcircus.enc.name}.${config.networking.domain}";
+  listenOn = "${config.networking.hostName}.${config.networking.domain}";
   serviceUser = "graylog";
 
 

--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -6,117 +6,18 @@ let
   cfg = config.flyingcircus.roles.loghost;
   fclib = import ../lib;
 
-  listenOn = "127.0.0.1";
-  serviceUser = "graylog";
-
   loghostService = findFirst
     (s: s.service == "loghost-server")
     null
     config.flyingcircus.enc_services;
 
-  # -- files --
-  rootPasswordFile = "/etc/local/graylog/password";
-  passwordSecretFile = "/etc/local/graylog/password_secret";
-  # -- passwords --
-  generatedRootPassword = mkPassword "graylog.rootPassword";
-  generatedPasswordSecret = mkPassword "graylog.passwordSecret";
-
-  rootPassword = removeSuffix "\n"
-    (if cfg.rootPassword  == null
-    then (fclib.configFromFile
-            rootPasswordFile
-            generatedRootPassword)
-    else cfg.rootPassword);
-
-  rootPasswordSha2 = mkSha2 rootPassword;
-
-  passwordSecret =
-    if cfg.passwordSecret == null
-    then (fclib.configFromFile
-            passwordSecretFile
-            generatedPasswordSecret)
-    else cfg.passwordSecret;
-
-
-  port = 9001;
-  webListenUri = "http://${listenOn}:${toString port}/tools/${config.flyingcircus.enc.name}/graylog";
-  restListenUri = "${webListenUri}/api";
-
-  # -- helper functions --
-  passwordActivation = file: password: user:
-    let script = ''
-     install -d -o ${toString config.ids.uids."${user}"} -g service -m 02775 \
-        $(dirname ${file})
-      if [[ ! -e ${file} ]]; then
-        ( umask 007;
-          echo ${password} > ${file}
-          chown ${user}:service ${file}
-        )
-      fi
-      chmod 0660 ${file}
-    '';
-    in script;
-
-  mkPassword = identifier:
-    removeSuffix "\n" (readFile
-      (pkgs.runCommand identifier { preferLocalBuild = true; }
-        "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out")
-      );
-
-  mkSha2 = text:
-    removeSuffix "\n" (readFile
-    (pkgs.runCommand "mkSha2" {
-      inherit text;
-      passAsFile = [ "text" ];
-    } "sha256sum < $textPath | cut -f1 -d \" \" > $out"));
-
-  logstashSSLHelper = with pkgs; writeScriptBin "logstash_ssl_import" ''
-    #!${stdenv.shell}
-    set -eu
-
-    puppet="puppet.$FCIO_LOCATION.gocept.net"
-    pw=$(${pwgen}/bin/pwgen -1 18)
-
-    scp $puppet:/var/lib/puppet/lumberjack/keys/$FCIO_HOSTNAME.{crt,key} /var/lib/graylog/
-    (cd /var/lib/graylog
-     ${openssl}/bin/openssl pkcs12 -export -in $FCIO_HOSTNAME.crt \
-                 -inkey $FCIO_HOSTNAME.key \
-                 -out $FCIO_HOSTNAME.p12 \
-                 -name $FCIO_HOSTNAME \
-                 -passin pass:$pw \
-                 -passout pass:$pw
-     rm -f $FCIO_HOSTNAME.jks
-     ${openjdk}/bin/keytool -importkeystore \
-                 -srckeystore $FCIO_HOSTNAME.p12 \
-                 -srcstoretype PKCS12\
-                 -srcstorepass $pw \
-                 -alias $FCIO_HOSTNAME \
-                 -deststorepass $pw \
-                 -destkeypass $pw \
-                 -destkeystore $FCIO_HOSTNAME.jks
-                 )
-    echo "keystore: /var/lib/graylog/$FCIO_HOSTNAME.jks"
-    echo "password: $pw"
-  '';
-
-  syslogPort = 5140;
-
-  esNodes =
-    ["${config.networking.hostName}.${config.networking.domain}:9350"
-     "${config.networking.hostName}.${config.networking.domain}:9300"] ++
-    map
-      (service: "${service.address}:9300")
-      (filter
-        (s: s.service == "elasticsearch-node")
-        config.flyingcircus.enc_services);
-
-    # It's common to have stathost and loghost on the same node. Each should
-    # use half of the memory then. A general approach for this kind of
-    # multi-service would be nice.
-    heapCorrection =
-      if config.flyingcircus.roles.statshost-master.enable
-      then 50
-      else 100;
+  # It's common to have stathost and loghost on the same node. Each should
+  # use half of the memory then. A general approach for this kind of
+  # multi-service would be nice.
+  heapCorrection =
+    if config.flyingcircus.roles.statshost-master.enable
+    then 50
+    else 100;
 
 in
 {
@@ -128,245 +29,33 @@ in
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = "Enable the Flying Circus graylog server role.";
-      };
+        description = ''Enable the Flying Circus loghost role.
 
-      rootPassword = mkOption {
-        type = types.nullOr types.string;
-        default = null;
-        description = ''
-          The password for of your graylogs's webui root user. If null, a random password will be generated.
+        This role enables the full graylog stack at once (GL, ES, Mongo).
+
         '';
-      };
-
-      passwordSecret = mkOption {
-        type = types.nullOr types.string;
-        default = null;
-        description = ''
-          A password secret for graylog. Use the same password secret fo the whole graylog
-          cluster. If null, a random password will be generated.
-        '';
-      };
-
-      heapPercentage = mkOption {
-        type = types.int;
-        default = 15 * heapCorrection / 100;
-        description = "How much RAM should go to graylog heap.";
       };
 
     };
 
   };
 
-  config = mkMerge [
-    (mkIf cfg.enable {
+  config = mkIf cfg.enable {
 
-      environment.systemPackages = [ logstashSSLHelper ];
-
-      networking.firewall.allowedTCPPorts = [ 9000 9002 ];
-
-      flyingcircus.roles.nginx.enable = true;
-      flyingcircus.roles.nginx.httpConfig =
-      let
-          listenOnPort = port: lib.concatMapStringsSep "\n    "
-              (addr: "listen ${addr}:${port};")
-              (fclib.listenAddressesQuotedV6 config "ethsrv");
-
-          allow = ips: lib.concatMapStringsSep "\n    "
-              (addr: "allow ${addr};")
-              (ips);
-
-      in
-      ''
-        server {
-            ${listenOnPort "9000"}
-
-            ${allow config.flyingcircus.static.directory.proxy_ips}
-            deny all;
-
-            location /tools/${config.flyingcircus.enc.name}/graylog {
-                proxy_pass http://127.0.0.1:9001;
-            }
-          }
-
-        server {
-            ${listenOnPort "9002"}
-
-            location /tools/${config.flyingcircus.enc.name}/graylog {
-                proxy_pass http://127.0.0.1:9001;
-                proxy_set_header REMOTE_USER "";
-                proxy_set_header X-Graylog-Server-URL http://${config.networking.hostName}.${config.networking.domain}:9002/tools/${config.flyingcircus.enc.name}/graylog/api;
-            }
-
-            location = / {
-              rewrite ^ /tools/${config.flyingcircus.enc.name}/graylog;
-            }
-          }
-      '';
-
-      system.activationScripts.fcio-loghost =
-        stringAfter
-          [ ]
-          (passwordActivation rootPasswordFile rootPassword serviceUser +
-           passwordActivation passwordSecretFile passwordSecret serviceUser);
-
-      services.graylog = {
-        enable = true;
-        elasticsearchClusterName = "graylog";
-        inherit passwordSecret rootPasswordSha2 webListenUri restListenUri;
-        elasticsearchDiscoveryZenPingUnicastHosts =
-          concatStringsSep "," esNodes;
-        javaHeap = ''${toString
-          (fclib.max [
-            ((fclib.current_memory config 1024) * cfg.heapPercentage / 100)
-            768
-            ])}m'';
-        extraConfig = ''
-          trusted_proxies 127.0.0.1/8
-          processbuffer_processors = ${toString
-            (fclib.max [
-              ((fclib.current_cores config 1) - 2)
-              5])}
-          outputbuffer_processors = ${toString
-            (fclib.max [
-              ((fclib.current_cores config 1) / 2)
-              3])}
-        '';
-      };
-
-      flyingcircus.roles.mongodb32.enable = true;
-      flyingcircus.roles.elasticsearch = {
-        enable = true;
-        dataDir = "/var/lib/elasticsearch";
-        clusterName = "graylog";
-        heapPercentage = 35 * heapCorrection / 100;
-        esNodes = esNodes;
-      };
-
-      systemd.services.graylog-config = {
-         description = "Enable Inputs for Graylog";
-         requires = [ "graylog.service" ];
-         after = [ "graylog.service" "mongodb.service" "elasticsearch.service" ];
-         wantedBy = [ "multi-user.target" ];
-         serviceConfig = {
-           Type = "oneshot";
-           User = config.services.graylog.user;
-           RemainAfterExit = true;
-         };
-         script = let
-           api = restListenUri;
-           user = "admin";
-           pw = rootPassword;
-
-           input_body = {
-             configuration = {
-               bind_address = "0.0.0.0";
-               expand_structured_data = false;
-               force_rdns = false;
-               recv_buffer_size = 262144;
-               store_full_message =  false;
-               allow_override_date =  true;
-               port = syslogPort;
-             };
-             title = "Syslog UDP"; # be careful changing it, it's used as
-                                   # a primary key for identifying the config
-                                   # object
-             type = "org.graylog2.inputs.syslog.udp.SyslogUDPInput";
-             global = true;
-           };
-          sso_body = {
-            default_group = "Admin";
-            auto_create_user = true;
-            username_header = "Remote-User";
-            fullname_header = "X-Graylog-Fullname";
-            email_header = "X-Graylog-Email";
-            require_trusted_proxies = true;
-            trusted_proxies = "127.0.0.1/8";
-          };
-        in
-          ''${pkgs.fcmanage}/bin/fc-graylog \
-          -u '${user}' \
-          -p '${removeSuffix "\n" pw}' \
-          '${api}' \
-          '${builtins.toJSON input_body}' \
-          '${builtins.toJSON sso_body}'
-          '' ;
-      };
-
-      systemd.services.graylog-update-geolite = {
-        description = "Update geolite db for graylog";
-        restartIfChanged = false;
-        after = [ "graylog.service" ];
-        serviceConfig = {
-          User = config.services.graylog.user;
-          Type = "oneshot";
-        };
-
-        script = ''
-          cd /var/lib/graylog
-          ${pkgs.curl}/bin/curl -O http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
-          ${pkgs.gzip}/bin/gunzip -f GeoLite2-City.mmdb.gz
-        '';
-      };
-
-      systemd.timers.graylog-update-geolite = {
-        description = "Timer for updating the geolite db for graylog";
-        wantedBy = [ "timers.target" ];
-        timerConfig = {
-          Unit = "graylog-update-geolite.service";
-          OnStartupSec = "10m";
-          OnUnitActiveSec = "30d";
-          # Not yet supported by our systemd version.
-          # RandomSec = "3m";
-        };
-      };
-
-      services.collectd.extraConfig = ''
-        LoadPlugin curl_json
-        <Plugin curl_json>
-          <URL "${restListenUri}/system/journal">
-            User "admin"
-            Password "${rootPassword}"
-            Header "Accept: application/json"
-            Instance "graylog"
-            <Key "uncommitted_journal_entries">
-              Type "gauge"
-            </Key>
-            <Key "append_events_per_second">
-              Type "gauge"
-            </Key>
-            <Key "read_events_per_second">
-              Type "gauge"
-            </Key>
-          </URL>
-          <URL "${restListenUri}/system/throughput">
-            User "admin"
-            Password "${rootPassword}"
-            Header "Accept: application/json"
-            Instance "graylog"
-            <Key "throughput">
-              Type "gauge"
-            </Key>
-          </URL>
-        </Plugin>
-      '';
-
-    flyingcircus.services.sensu-client.checks = {
-      graylog_ui = {
-        notification = "Graylog UI alive";
-        command = ''
-          check_http -H ${listenOn} -p ${toString port} \
-            -u /tools/${config.networking.hostName}/graylog/
-        '';
-      };
+    flyingcircus.roles.graylog = {
+      enable = true;
+      heapPercentage = 15 * heapCorrection / 100;
+      cluster = false;
     };
 
-    })
-    # This configuration part defines loghosts clients as loghosts which happen to be their own clients as well
-    (mkIf (loghostService != null) {
-      flyingcircus.syslog.extraRules = ''
-        *.* @${loghostService.address}:${toString syslogPort};RSYSLOG_SyslogProtocol23Format
-      '';
-    }
-    )];
-  }
+    flyingcircus.roles.elasticsearch = {
+      enable = true;
+      dataDir = "/var/lib/elasticsearch";
+      clusterName = "graylog";
+      heapPercentage = 35 * heapCorrection / 100;
+      esNodes = config.flyingcircus.roles.graylog.esNodes;
+    };
+
+  };
+
+}

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -5,6 +5,8 @@
 
   elasticsearch = hydraJob (import ./elasticsearch.nix { inherit system; });
 
+  graylog = hydraJob (import ./graylog.nix { inherit system; });
+
   haproxy = hydraJob (import ./haproxy.nix { inherit system; });
 
   login = hydraJob (import ./login.nix { inherit system; });

--- a/nixos/modules/flyingcircus/tests/graylog.nix
+++ b/nixos/modules/flyingcircus/tests/graylog.nix
@@ -1,0 +1,51 @@
+import ../../../tests/make-test.nix ({ lib, pkgs, ... }:
+{
+  name = "graylog";
+  machine =
+    { config, ... }:
+    {
+      imports = [
+        ./setup.nix
+        ../platform
+        ../roles
+        ../services
+        ../static
+      ];
+
+      virtualisation.memorySize = 4096;
+
+      flyingcircus.roles.loghost.enable = true;
+      networking.domain = "local";
+      flyingcircus.enc.parameters.directory_password = "asdf";
+      flyingcircus.enc.parameters.resource_group = "test";
+      flyingcircus.enc_addresses.srv = [
+        {
+         "ip" = "127.0.0.1/24";
+         "mac" = "02:00:00:03:13:5B";
+         "name" = "machine";
+         "rg" = "test";
+         "ring" = 1;
+         "vlan" = "srv";
+        }
+      ];
+      users.groups.login = {
+        members = [];
+      };
+      flyingcircus.enc_services = [
+        { service = "loghost-server";
+          address = "machine.local";
+        }
+      ];
+      networking.extraHosts = ''
+        127.0.0.1 machine.local
+      '';
+
+    };
+  testScript = ''
+    $machine->waitForUnit("nginx.service");
+    $machine->waitForUnit("haproxy.service");
+    $machine->waitForUnit("graylog.service");
+    $machine->waitForUnit("mongodb.service");
+    $machine->waitForUnit("elasticsearch.service");
+  '';
+})


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: Graylog instances will be restarted.

Changelog: 

* Loghosts can be scaled for higher load of messages and better availability, by having multiple Graylog instances, and/or multiple ElasticSearch instances, including MongoDB replication.
* Browser access to graylog is no longer proxied through our self-service portal. A public IP will be needed to access Graylog. Users will user their Flying Cirucs login to directly authenticate against Graylog.


Details: 

* Provide separate graylog role, which only enables graylog, and connects to any ES in the "graylog" cluster.
* Enable LDAP authentication for direct access to graylog, without needing to go through our central proxy
* Setup HAProxy in front of a GELF TCP input. Each graylog node has an HAProxy talking to each graylog.
