### PR TITLE
Allow nonlocal ("early") binds so that startup order is not _that_ im…

### DIFF
--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -237,6 +237,8 @@ in
       (hostsFromEncAddresses cfg.enc_addresses.srv);
 
     boot.kernel.sysctl = {
+      "net.ipv4.ip_nonlocal_bind" = "1";
+      "net.ipv6.ip_nonlocal_bind" = "1";
       "net.ipv4.ip_local_port_range" = "32768 60999";
       "net.ipv4.ip_local_reserved_ports" = "61000-61999";
       # work around CVE-2016-5696


### PR DESCRIPTION
…portant

in the future.

Re #28908

@flyingcircusio/release-managers

Impact:

Changelog:

* Allow non-local binds: this allows binding to IP adresses that may not have been configured (yet) and thus stabilizes the startup behaviour for services like nginx and varnish even in the face of ordering issues. However, this also means that configuring wrong listen addresses may remain unnoticed.