### PR TITLE
Proivde a useful default for graylog's public name

### DIFF
--- a/nixos/modules/flyingcircus/roles/graylog.nix
+++ b/nixos/modules/flyingcircus/roles/graylog.nix
@@ -206,7 +206,7 @@ in
 
         hostName = mkOption {
           type = types.nullOr types.str;
-          default = null;
+          default = "graylog.${config.flyingcircus.enc.parameters.resource_group}.fcio.net";
           description = "HTTP host name for the GL frontend.";
           example = "graylog.example.com";
         };


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: none
