### PR TITLE
graylog: Use a sensible queue timeout for haproxy

### DIFF
--- a/nixos/modules/flyingcircus/roles/graylog.nix
+++ b/nixos/modules/flyingcircus/roles/graylog.nix
@@ -541,7 +541,7 @@ in
             timeout connect 5s
             timeout client 30s    # should be equal to server timeout
             timeout server 30s    # should be equal to client timeout
-            timeout queue 2
+            timeout queue 30s
 
         listen gelf-tcp-in
         ${listenConfig gelfTCPHAPort}


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: Graylog: Use a sensible HAProxy queue timeout (30s) for the Graylog UI and API.
