### PR TITLE
Add htop to our default environment

### DIFF
--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -29,6 +29,7 @@
         go
         gptfdisk
         graphviz
+        htop
         imagemagick
         iotop
         kerberos


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: This add htop to our default environment. Most users won't see any difference

Changelog: Add htop to default environment
