### PR TITLE
Explicitly bind Grafana to ethfe.

### DIFF
--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -437,11 +437,14 @@ in
             }
 
           '';
+          listenOnPort = interface: port:
+            lib.concatMapStringsSep "\n    "
+                (addr: "listen ${addr}:${toString port};")
+                (fclib.listenAddressesQuotedV6 config interface);
         in
         if cfgStatsGlobal.useSSL then ''
           server {
-              listen *:80;
-              listen [::]:80;
+          ${listenOnPort "ethfe" 80}
               server_name ${httpHost};
 
               location / {
@@ -450,8 +453,7 @@ in
           }
 
           server {
-              listen *:443 ssl;
-              listen [::]:443 ssl;
+          ${listenOnPort "ethfe" "443 ssl http2"}
               ${common}
 
               ssl_certificate ${/etc/local/nginx/stats.crt};
@@ -462,8 +464,7 @@ in
         else
         ''
           server {
-              listen *:80;
-              listen [::]:80;
+          ${listenOnPort "ethfe" 80}
               ${common}
           }
         '';

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -444,7 +444,7 @@ in
         in
         if cfgStatsGlobal.useSSL then ''
           server {
-          ${listenOnPort "ethfe" 80}
+              ${listenOnPort "ethfe" 80}
               server_name ${httpHost};
 
               location / {
@@ -453,7 +453,7 @@ in
           }
 
           server {
-          ${listenOnPort "ethfe" "443 ssl http2"}
+              ${listenOnPort "ethfe" "443 ssl http2"}
               ${common}
 
               ssl_certificate ${/etc/local/nginx/stats.crt};
@@ -464,7 +464,7 @@ in
         else
         ''
           server {
-          ${listenOnPort "ethfe" 80}
+              ${listenOnPort "ethfe" 80}
               ${common}
           }
         '';


### PR DESCRIPTION
This especially fixes SSL issues with Graylog and Grafana on the same VM.

@flyingcircusio/release-managers

Impact:

Changelog: Fix SSL for Graylog and Grafana (loghost) on the same VM.
