### PR TITLE
Provide NodeJS8, and update other Versions

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -232,6 +232,6 @@ in rec {
   xtrabackup = pkgs.callPackage ./percona/xtrabackup.nix { };
   xulrunner = pkgs_17_09.xulrunner;
 
-  yarn = pkgs.callPackage ./yarn.nix { nodejs = nodejs8; };
+  yarn = pkgs.callPackage ./yarn.nix { nodejs = nodejs7; };
 
 }

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -126,8 +126,12 @@ in rec {
 
   nix = pkgs_17_09.nix;
 
+  nodejs4 = pkgs_17_09.nodejs-4_x;
+  nodejs6 = pkgs_17_09.nodejs-6_x;
+  nodejs8 = pkgs_17_09.nodejs-8_x;
+
   inherit (pkgs.callPackage ./nodejs { libuv = pkgs.libuvVersions.v1_9_1; })
-    nodejs4 nodejs6 nodejs7;
+    nodejs7;
 
   inherit (pkgs.callPackages ./openssl {
       fetchurl = pkgs.fetchurlBoot;
@@ -228,6 +232,6 @@ in rec {
   xtrabackup = pkgs.callPackage ./percona/xtrabackup.nix { };
   xulrunner = pkgs_17_09.xulrunner;
 
-  yarn = pkgs.callPackage ./yarn.nix { nodejs = nodejs7; };
+  yarn = pkgs.callPackage ./yarn.nix { nodejs = nodejs8; };
 
 }

--- a/nixos/modules/flyingcircus/packages/nodejs/default.nix
+++ b/nixos/modules/flyingcircus/packages/nodejs/default.nix
@@ -56,21 +56,6 @@ let
   };
 
 in {
-  nodejs4 = common rec {
-    version = "4.8.4";
-    src = fetchurl {
-      url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
-      sha256 = "35fe633a48cbe93c79327161d9dc964ac9810f4ceb2ed8628487e6e14a15905b";
-    };
-  };
-
-  nodejs6 = common rec {
-    version = "6.11.1";
-    src = fetchurl {
-      url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-      sha256 = "0187d4e4ef00cee2b70b0ad0689100050654f26629775d097b145d0d8727f9a0";
-    };
-  };
 
   nodejs7 = common rec {
     version = "7.10.1";

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -18,7 +18,7 @@
   mongodb = hydraJob (import ./mongodb { inherit system; });
 
   inherit (import ./nodejs.nix { inherit system hydraJob; })
-    nodejs_4 nodejs_6 nodejs_7;
+    nodejs_4 nodejs_6 nodejs_7 nodejs_8;
 
   inherit (import ./mysql.nix { inherit system hydraJob; })
     mysql_5_5 mysql_5_6 mysql_5_7;

--- a/nixos/modules/flyingcircus/tests/nodejs.nix
+++ b/nixos/modules/flyingcircus/tests/nodejs.nix
@@ -41,5 +41,6 @@ in
   nodejs_4 = testFactory "nodejs4" "v4.";
   nodejs_6 = testFactory "nodejs6" "v6.";
   nodejs_7 = testFactory "nodejs7" "v7.";
+  nodejs_8 = testFactory "nodejs8" "v8.";
 }
 


### PR DESCRIPTION
nodejs-4.8.5
nodejs-6.11.5
nodejs-8.9.0

re #29513

@flyingcircusio/release-managers

Impact:

Changelog: 
* Add NodeJS 8.9.0
* Update NodeJS (4.8.5, 6.11.5)