### PR TITLE
prometheus: allow longer configuration files

### DIFF
--- a/nixos/modules/flyingcircus/services/prometheus/default.nix
+++ b/nixos/modules/flyingcircus/services/prometheus/default.nix
@@ -13,7 +13,7 @@ let
   # Pretty-print JSON to a file
   writePrettyJSON = name: x:
     pkgs.runCommand name { } ''
-      echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out
+      cat ${pkgs.writeText "config.json" (builtins.toJSON x)} | ${pkgs.jq}/bin/jq . > $out
     '';
 
   # This becomes the main config file

--- a/nixos/modules/flyingcircus/services/prometheus/default.nix
+++ b/nixos/modules/flyingcircus/services/prometheus/default.nix
@@ -12,9 +12,10 @@ let
 
   # Pretty-print JSON to a file
   writePrettyJSON = name: x:
-    pkgs.runCommand name { } ''
-      cat ${pkgs.writeText "config.json" (builtins.toJSON x)} | ${pkgs.jq}/bin/jq . > $out
-    '';
+    with pkgs;
+    let
+      compactJSON = writeText "prometheus.json" (builtins.toJSON x);
+    in runCommand name { } "${jq}/bin/jq . < ${compactJSON} > $out";
 
   # This becomes the main config file
   promConfig = {
@@ -25,6 +26,7 @@ let
     scrape_configs = cfg.scrapeConfigs;
   };
 
+  # JSON output is also valid YAML
   generatedPrometheusYml = writePrettyJSON "prometheus.yml" promConfig;
 
   prometheusYml =


### PR DESCRIPTION
In certain cases the config is rather long. Using echo just fails miserably.

@flyingcircusio/release-managers

Impact:

Changelog: Allow larger Prometheus configurations.


