### PR TITLE
Security update rsync: 3.1.2 -> 3.1.3

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -7,18 +7,18 @@ assert enableACLs -> acl != null;
 
 stdenv.mkDerivation rec {
   name = "rsync-${version}";
-  version = "3.1.2";
+  version = "3.1.3";
 
   mainSrc = fetchurl {
     # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
     url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
-    sha256 = "1hm1q04hz15509f0p9bflw4d6jzfvpm1d36dxjwihk1wzakn5ypc";
+    sha256 = "1h0011dj6jgqpgribir4anljjv7bbrdcs8g91pbsmzf5zr75bk2m";
   };
 
   patchesSrc = fetchurl {
     # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
     url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
-    sha256 = "09i3dcl37p22dp75vlnsvx7bm05ggafnrf1zwhf2kbij4ngvxvpd";
+    sha256 = "167vk463bb3xl9c4gsbxms111dk1ip7pq8y361xc0xfa427q9hhd";
   };
 
   srcs = [mainSrc] ++ stdenv.lib.optional enableCopyDevicesPatch patchesSrc;


### PR DESCRIPTION
Fixes #29124

@flyingcircusio/release-managers

Impact:


Changelog:

* Security update rsync: 3.1.2 -> 3.1.3 (#29124)
