### PR TITLE
Security update OpenSSL: -> 1.0.1g, -> 1.0.2n

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -145,6 +145,9 @@ in rec {
   inherit (pkgs.callPackage ./nodejs { libuv = pkgs.libuvVersions.v1_9_1; })
     nodejs7;
 
+
+  openssh = pkgs_17_09.openssh;
+
   inherit (pkgs.callPackages ./openssl {
       fetchurl = pkgs.fetchurlBoot;
       cryptodevHeaders = pkgs.linuxPackages.cryptodev.override {
@@ -152,8 +155,12 @@ in rec {
         onlyHeaders = true;
       };
     })
-    openssl_1_0_2 openssl_1_1_0 openssl_1_0_1;
+    openssl_1_0_2 openssl_1_1_0 ;
   openssl = openssl_1_0_2;
+
+  # We don't want anyone to still use openssl 1.0.1 so I'm putting this in as
+  # a null value to break any dependency explicitly.
+  openssl_1_0_1 = null;
 
   osm2pgsql = pkgs.callPackage ./osm2pgsql.nix { };
   osrm-backend = pkgs.callPackage ./osrm-backend { };

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -33,6 +33,7 @@ in rec {
     nodejs-4_x
     nodejs-6_x
     nodejs-8_x
+    openssh
     php70Packages
     prometheus
     prometheus-haproxy-exporter
@@ -144,9 +145,6 @@ in rec {
 
   inherit (pkgs.callPackage ./nodejs { libuv = pkgs.libuvVersions.v1_9_1; })
     nodejs7;
-
-
-  openssh = pkgs_17_09.openssh;
 
   inherit (pkgs.callPackages ./openssl {
       fetchurl = pkgs.fetchurlBoot;

--- a/nixos/modules/flyingcircus/packages/openssl/default.nix
+++ b/nixos/modules/flyingcircus/packages/openssl/default.nix
@@ -12,6 +12,7 @@ let
     name = "openssl-${version}${release}";
 
     src = fetchurl {
+      # Our curl doesn't yet support SSL, so ...
       url = "http://downloads.fcio.net/openssl/${name}.tar.gz";
       inherit sha256;
     };
@@ -102,22 +103,16 @@ let
 
 in {
 
-  openssl_1_0_1 = common {
-    version = "1.0.1";
-    release = "u";
-    sha256 = "0fb7y9pwbd76pgzd7xzqfrzibmc0vf03sl07f34z5dhm2b5b84j3";
-  };
-
   openssl_1_0_2 = common {
     version = "1.0.2";
-    release = "l";
-    sha256 = "037kvpisc6qh5dkppcwbm5bg2q800xh2hma3vghz8xcycmdij1yf";
+    release = "n";
+    sha256 = "1zm82pyq5a9jm10q6iv7d3dih3xwjds4x30fqph3k317byvsn2rp";
   };
 
   openssl_1_1_0 = common {
     version = "1.1.0";
-    release = "f";
-    sha256 = "0r97n4n552ns571diz54qsgarihrxvbn7kvyv8wjyfs9ybrldxqj";
+    release = "g";
+    sha256 = "1zm82pyq5a9jm10q6iv7d3dih3xwjds4x30fqph3k317byvsn2rp";
   };
 
 }


### PR DESCRIPTION
Also includes an update to OpenSSH due to aged build script issues.

Fixes #29247

@flyingcircusio/release-managers

Impact:

* Various services that link against OpenSSL will be restarted.
* OpenSSH servers will be restarted.
* OpenSSH has widely updated their cryptographic policies and disabled various (very) outdated protocols like SSHv1. For details check https://www.openssh.com/releasenotes.html for incompatible changes between version 6.9 and 7.5.

Changelog:

* Security update OpenSSL: -> 1.0.1g, -> 1.0.2n
* Update OpenSSH: 6.9 -> 7.5