### PR TITLE
29308 stathost fix relayed node update

### DIFF
--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -343,7 +343,7 @@ in
         path = [ pkgs.curl pkgs.coreutils ];
         script = concatStringsSep "\n" (map
           (relayNode: ''
-            curl -o /var/cache/statshost-relay-${relayNode.job_name}.json \
+            curl -s -o /var/cache/statshost-relay-${relayNode.job_name}.json \
               ${relayNode.proxy_url}/scrapeconfig.json
           '')
           relayNodes);

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -331,7 +331,7 @@ in
       };
 
       # Update relayed nodes.
-      systemd.services.fc-prometheus-update-relayed-nodes = {
+      systemd.services.fc-prometheus-update-relayed-nodes = (mkIf (relayNodes != []) {
         description = "Update prometheus proxy relayed nodes.";
         restartIfChanged = false;
         after = [ "network.target" ];
@@ -347,9 +347,9 @@ in
               ${relayNode.proxy_url}/scrapeconfig.json
           '')
           relayNodes);
-      };
+      });
 
-      systemd.timers.fc-prometheus-update-relayed-nodes = {
+      systemd.timers.fc-prometheus-update-relayed-nodes = (mkIf (relayNodes != []) {
         description = "Timer for updating relayed targets";
         wantedBy = [ "timers.target" ];
         timerConfig = {
@@ -358,7 +358,7 @@ in
           # Not yet supported by our systemd version.
           # RandomSec = "3m";
         };
-      };
+      });
 
 
       flyingcircus.services.sensu-client.checks = {


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: Statshost: Don't create empty relay update script when there are no relays to update (#29308).
