### PR TITLE
Use updated libarchive version with additional security patches.

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -83,6 +83,8 @@ in rec {
 
   kibana = pkgs_17_09.kibana;
 
+  libarchive = pkgs_17_09.libarchive;
+
   libevent = pkgs.callPackage ./libevent.nix { };
   libidn = pkgs.callPackage ./libidn.nix { };
   libreoffice = pkgs_17_09.libreoffice-fresh;


### PR DESCRIPTION
Partially fixes #28596

@flyingcircusio/release-managers

Impact:

* Many services will be restarted due to the libarchive update which is widely depended upon.

Changelog:

* Update libarchive with additional patches for ongoing CVEs. Partially fixes #28596.
