### PR TITLE
Security update for Subversion: 1.8.15 -> 1.8.19

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -211,7 +211,10 @@ in rec {
   rustUnstable = rustPlatform;
 
   samba = pkgs_17_09.samba;
+
   sensu = pkgs.callPackage ./sensu { };
+
+  subversion = pkgs_17_09.subversion18;
 
   telegraf = pkgs.callPackage ./telegraf {
     inherit (pkgs_17_09) buildGoPackage fetchgit;


### PR DESCRIPTION
Fixes #29025

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for Subversion: 1.8.15 -> 1.8.19. Fixes #29025