### PR TITLE
Security update for git: 2.14.2 -> 2.15

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -63,6 +63,8 @@ in rec {
   fcuserscan = pkgs.callPackage ./fcuserscan.nix { } ;
   firefox = pkgs_17_09.firefox;
 
+  git = pkgs_17_09.git;
+
   grafana = pkgs_17_09.callPackage ./grafana { };
   graphicsmagick = pkgs_17_09.graphicsmagick;
   graylog = pkgs.callPackage ./graylog.nix { };


### PR DESCRIPTION
Fixes #29024

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for git: 2.14.2 -> 2.15. Fixes #29024