### PR TITLE
Revert "Use updated libarchive version with additional security patches."

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -83,8 +83,6 @@ in rec {
 
   kibana = pkgs_17_09.kibana;
 
-  libarchive = pkgs_17_09.libarchive;
-
   libevent = pkgs.callPackage ./libevent.nix { };
   libidn = pkgs.callPackage ./libidn.nix { };
   libreoffice = pkgs_17_09.libreoffice-fresh;


### PR DESCRIPTION
Reverts flyingcircusio/nixpkgs#351

Build failure in cmake (dependency via postgis)

https://hydra.flyingcircus.io/build/19614

Re #28596