### PR TITLE
Backport strongSwan 5.6 from 17.09

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -40,6 +40,7 @@ in rec {
     remarshal
     ripgrep
     samba
+    strongswan
     subversion18
     virtualbox
     xulrunner;

--- a/nixos/modules/flyingcircus/services/default.nix
+++ b/nixos/modules/flyingcircus/services/default.nix
@@ -20,13 +20,7 @@
      ./sensu/client.nix
      ./sensu/server.nix
      ./sensu/uchiwa.nix
+     ./strongswan.nix
      ./telegraf.nix
     ];
-
-  # get rid of sadc logs as we have a better metrics infrastructure now
-  # remove this after 2018-02-01
-  system.activationScripts.sysstat = {
-    text = "rm -rf /var/log/sa";
-    deps = [];
-  };
 }

--- a/nixos/modules/flyingcircus/services/strongswan.nix
+++ b/nixos/modules/flyingcircus/services/strongswan.nix
@@ -1,3 +1,6 @@
+# strongSwan service ripped from release-17.09
+# we can probably go back to the stock service definition after upgrading to
+# 17.09+
 { config, lib, pkgs, ... }:
 
 let
@@ -49,7 +52,7 @@ let
 in
 {
   options.services.strongswan = {
-    enable = mkEnableOption "strongSwan";
+    enable = mkEnableOption "strongSwan 5.6.x";
 
     secrets = mkOption {
       type = types.listOf types.path;
@@ -115,12 +118,12 @@ in
   };
 
   config = with cfg; mkIf enable {
-    systemd.services.strongswan = {
+    systemd.services.strongswan56 = {
       description = "strongSwan IPSec Service";
       wantedBy = [ "multi-user.target" ];
       path = with pkgs; [ kmod iproute iptables utillinux ]; # XXX Linux
       wants = [ "keys.target" ];
-      after = [ "network.target" "keys.target" ];
+      after = [ "network-online.target" "keys.target" ];
       environment = {
         STRONGSWAN_CONF = strongswanConf { inherit setup connections ca secrets; };
       };

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -339,7 +339,6 @@
   ./services/networking/sslh.nix
   ./services/networking/ssh/lshd.nix
   ./services/networking/ssh/sshd.nix
-  ./services/networking/strongswan.nix
   ./services/networking/supybot.nix
   ./services/networking/syncthing.nix
   ./services/networking/tcpcrypt.nix


### PR DESCRIPTION
This PR updates strongSwan to 5.6 and make it installable on our platform. 

Christian removed the strongswan service from nixos/modules/services/networking and placed a copy of the up-to-date version into our overlay. This can be reverted on the next base system update.

Re #29822

@flyingcircusio/release-managers

Impact:

Changelog: 
* Allow to install strongSwan 5.6 
