### PR TITLE
Fix Sensu API authentication configuration.

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/api.nix
+++ b/nixos/modules/flyingcircus/services/sensu/api.nix
@@ -17,7 +17,12 @@ let
     (x: x.node == "${config.networking.hostName}.gocept.net")
     { password = ""; } { password = ""; } sensu_clients).password;
 
-  sensu_api_json = pkgs.writeText "sensu-server.json"
+  api_password = (lib.findSingle
+    (x: x.service == "sensuserver-api" &&
+        x.address == "${config.networking.hostName}.gocept.net")
+    { password = ""; } { password = ""; } config.flyingcircus.enc_services).password;
+
+  sensu_api_json = pkgs.writeText "sensu-api.json"
     ''
     {
       "rabbitmq": {
@@ -25,6 +30,10 @@ let
         "user": "sensu-server",
         "password": "${server_password}",
         "vhost": "/sensu"
+      },
+      "api": {
+        "user": "sensuserver-api",
+        "password": "${api_password}"
       }
     }
     '';

--- a/nixos/modules/flyingcircus/services/sensu/uchiwa.nix
+++ b/nixos/modules/flyingcircus/services/sensu/uchiwa.nix
@@ -29,7 +29,7 @@ let
             "insecure": true,
             "path": "/api",
             "timeout": 5,
-            "user": "${config.networking.hostName}.gocept.net"  ,
+            "user": "sensuserver-api"  ,
             "pass": "${api_server.password}"
            }'')
       api_servers);


### PR DESCRIPTION
The clients were already using the right settings but the server was running
with an empty username/password pair (and would still allow access with
differing credentials).

Fixes #100173

@flyingcircusio/release-managers

Impact:

Changelog:

* Fix Sensu API authentication.