### PR TITLE
Security update for libarchive 3.3.2 to a selectively patched version.

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -19,6 +19,7 @@ in rec {
   inherit (pkgs_17_09)
     audiofile
     bundlerApp
+    cmake
     elasticsearch2
     elasticsearch5
     firefox
@@ -26,6 +27,7 @@ in rec {
     graphicsmagick
     iptables
     kibana
+    libarchive
     libreoffice-fresh
     mailutils
     nix


### PR DESCRIPTION
Includes an update for cmake due to compatibility issues.

Fixes #28596.

@flyingcircusio/release-managers

Impact:

* May restart a number of services depending on libarchive.

Changelog:

* Security update for libarchive 3.3.2 to a selectively patched version.
* Update for cmake due to NixOS 17.09 compatibility issues.
