### PR TITLE
Automatically restart crashed InfluxDBs.

### DIFF
--- a/nixos/modules/flyingcircus/services/influxdb011.nix
+++ b/nixos/modules/flyingcircus/services/influxdb011.nix
@@ -170,6 +170,8 @@ in
         User = "${cfg.user}";
         Group = "${cfg.group}";
         PermissionsStartOnly = true;
+        Restart = "always";
+        RestartSec = "5s";
       };
       preStart = ''
         mkdir -m 0770 -p ${cfg.dataDir}


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

* InfluxDB services will be restarted.

Changelog:

* Configure InfluxDBs' systemd unit to automatically restart after crashes.