### PR TITLE
28725 fix rabbitmq update

### DIFF
--- a/nixos/modules/flyingcircus/packages/rabbitmq-server.nix
+++ b/nixos/modules/flyingcircus/packages/rabbitmq-server.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchurl, erlang, python, libxml2, libxslt, xmlto
-, docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync }:
+, docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync
+}:
 
 stdenv.mkDerivation rec {
   name = "rabbitmq-server-${version}";
 
-  version = "3.6.5";
+  version = "3.6.12";
 
   src = fetchurl {
-    url = "http://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
-    sha256 = "1v48ay4z8n9q9c8rg7fhrfa4cg2dqiwbjnr3yl5i7xdam0y46l4m";
+    url = "https://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
+    sha256 = "1faqnk6cn7xhn2hx3ayqxwbfnl3dybcipx2h02m6fqdfbbnsirf8";
   };
 
   buildInputs =
@@ -21,19 +22,12 @@ stdenv.mkDerivation rec {
     '';
 
   installFlags = "PREFIX=$(out) RMQ_ERLAPP_DIR=$(out)";
-
-  preInstall =
-    ''
-      sed -i \
-        -e 's|SYS_PREFIX=|SYS_PREFIX=''${SYS_PREFIX-''${HOME}/.rabbitmq/${version}}|' \
-        -e 's|CONF_ENV_FILE=''${SYS_PREFIX}\(.*\)|CONF_ENV_FILE=\1|' \
-        scripts/rabbitmq-defaults
-    '';
+  installTargets = "install install-man";
 
   postInstall =
     ''
-      echo 'PATH=${erlang}/bin:${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
-    ''; # */
+      echo 'PATH=${erlang}/bin:''${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
+    '';
 
   meta = {
     homepage = http://www.rabbitmq.com/;

--- a/nixos/modules/flyingcircus/packages/rabbitmq-server.nix
+++ b/nixos/modules/flyingcircus/packages/rabbitmq-server.nix
@@ -5,11 +5,11 @@
 stdenv.mkDerivation rec {
   name = "rabbitmq-server-${version}";
 
-  version = "3.6.12";
+  version = "3.6.15";
 
   src = fetchurl {
     url = "https://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
-    sha256 = "1faqnk6cn7xhn2hx3ayqxwbfnl3dybcipx2h02m6fqdfbbnsirf8";
+    sha256 = "1zdmil657mhjmd20jv47s5dfpj2liqwvyg0zv2ky3akanfpgj98y";
   };
 
   buildInputs =

--- a/nixos/modules/flyingcircus/roles/rabbitmq.nix
+++ b/nixos/modules/flyingcircus/roles/rabbitmq.nix
@@ -58,14 +58,14 @@ in
     '';
 
     environment.etc."local/rabbitmq/README.txt".text = ''
-        RabbitMQ (${pkgs.rabbitmq_server.version}) is running on this machine.
+      RabbitMQ (${pkgs.rabbitmq_server.version}) is running on this machine.
 
-        If you need to set non-default configuration options, you can put a
-        file called rabbitmq.config into this directory. The content of this
-        file will be added the configuration of the RabbitMQ-service.
+      If you need to set non-default configuration options, you can put a
+      file called rabbitmq.config into this directory. The content of this
+      file will be added the configuration of the RabbitMQ-service.
 
-        To access rabbitmqctl and other management tools, change into rabbitmq's
-        user and run your command(s). Example:
+      To access rabbitmqctl and other management tools, change into rabbitmq's
+      user and run your command(s). Example:
 
         $ sudo -iu rabbitmq
         % rabbitmqctl status

--- a/nixos/modules/flyingcircus/services/rabbitmq.nix
+++ b/nixos/modules/flyingcircus/services/rabbitmq.nix
@@ -24,6 +24,13 @@ let
   };
 
 in {
+  options = {
+    services.rabbitmq.pluginPackages = mkOption {
+      default = [];
+      type = types.listOf types.package;
+      description = "Packages to add as plugin.";
+    };
+  };
 
   config = mkIf cfg.enable {
     systemd.services.rabbitmq.environment = {

--- a/nixos/modules/flyingcircus/services/rabbitmq.nix
+++ b/nixos/modules/flyingcircus/services/rabbitmq.nix
@@ -36,5 +36,6 @@ in {
     systemd.services.rabbitmq.environment = {
         RABBITMQ_PLUGINS_DIR = plugins;
     };
+    systemd.services.rabbitmq.path = [ pkgs.glibc ];
   };
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

* Restarts all RabbitMQ servers and takes bit of time (~10-15s)  to migrate the on-disk databases.

Changelog:

* Security update for RabbitMQ. #28725 