### PR TITLE
Revert "Security update for libarchive 3.3.2 to a selectively patched version."

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -21,7 +21,6 @@ in rec {
   inherit (pkgs_17_09)
     audiofile
     bundlerApp
-    cmake
     elasticsearch2
     elasticsearch5
     firefox
@@ -29,7 +28,6 @@ in rec {
     graphicsmagick
     iptables
     kibana
-    libarchive
     libreoffice-fresh
     mailutils
     nix


### PR DESCRIPTION
Reverts flyingcircusio/nixpkgs#360

Leads to build failures in osrm-server and potentially other packages. This seems to be a side effect of a cmake/pkgconfig incompatibility (?). I have seen errors with multiple output/closure size reduction ($lib vs. $out) and possibly a change pkg setup hook in pkgconfig.