### PR TITLE
Update libarchive inline due to multi-output dependency problems.

### DIFF
--- a/pkgs/development/libraries/libarchive/CVE-2017-14166.patch
+++ b/pkgs/development/libraries/libarchive/CVE-2017-14166.patch
@@ -1,0 +1,36 @@
+From fa7438a0ff4033e4741c807394a9af6207940d71 Mon Sep 17 00:00:00 2001
+From: Joerg Sonnenberger <joerg@bec.de>
+Date: Tue, 5 Sep 2017 18:12:19 +0200
+Subject: [PATCH] Do something sensible for empty strings to make fuzzers
+ happy.
+
+---
+ libarchive/archive_read_support_format_xar.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/libarchive/archive_read_support_format_xar.c b/libarchive/archive_read_support_format_xar.c
+index 7a22beb9d..93eeacc5e 100644
+--- a/libarchive/archive_read_support_format_xar.c
++++ b/libarchive/archive_read_support_format_xar.c
+@@ -1040,6 +1040,9 @@ atol10(const char *p, size_t char_cnt)
+ 	uint64_t l;
+ 	int digit;
+ 
++	if (char_cnt == 0)
++		return (0);
++
+ 	l = 0;
+ 	digit = *p - '0';
+ 	while (digit >= 0 && digit < 10  && char_cnt-- > 0) {
+@@ -1054,7 +1057,10 @@ atol8(const char *p, size_t char_cnt)
+ {
+ 	int64_t l;
+ 	int digit;
+-        
++
++	if (char_cnt == 0)
++		return (0);
++
+ 	l = 0;
+ 	while (char_cnt-- > 0) {
+ 		if (*p >= '0' && *p <= '7')

--- a/pkgs/development/libraries/libarchive/CVE-2017-14502.patch
+++ b/pkgs/development/libraries/libarchive/CVE-2017-14502.patch
@@ -1,0 +1,28 @@
+From 5562545b5562f6d12a4ef991fae158bf4ccf92b6 Mon Sep 17 00:00:00 2001
+From: Joerg Sonnenberger <joerg@bec.de>
+Date: Sat, 9 Sep 2017 17:47:32 +0200
+Subject: [PATCH] Avoid a read off-by-one error for UTF16 names in RAR
+ archives.
+
+Reported-By: OSS-Fuzz issue 573
+---
+ libarchive/archive_read_support_format_rar.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index cbb14c32d..751de6979 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -1496,7 +1496,11 @@ read_header(struct archive_read *a, struct archive_entry *entry,
+         return (ARCHIVE_FATAL);
+       }
+       filename[filename_size++] = '\0';
+-      filename[filename_size++] = '\0';
++      /*
++       * Do not increment filename_size here as the computations below
++       * add the space for the terminating NUL explicitly.
++       */
++      filename[filename_size] = '\0';
+
+       /* Decoded unicode form is UTF-16BE, so we have to update a string
+        * conversion object for it. */

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "1km0mzfl6in7l5vz9kl09a88ajx562rw93ng9h2jqavrailvsbgd";
   };
 
+  patches = [
+    ./CVE-2017-14166.patch
+    ./CVE-2017-14502.patch
+  ];
+
   buildInputs = [ sharutils libxml2 zlib bzip2 openssl xz ] ++
     stdenv.lib.optionals stdenv.isLinux [ e2fsprogs attr acl ];
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

* Many services whose built depends on libarchive may be restarted.

Changelog:

* Update libarchive with patches for CVEs as available.
