### PR TITLE
Adjust our swap checks: some usage is fine, but more than 1g is not a…

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcsensuplugins/fc/sensuplugins/swap.py
+++ b/nixos/modules/flyingcircus/packages/fcsensuplugins/fc/sensuplugins/swap.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Swap usage check.
+
+The main feature of this check is to test for absolute swap usage, which the
+default check_swap of Nagios can't do.
+
+"""
+
+import argparse
+import psutil
+import sys
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--critical', '-c', type=int, default=2048,
+                   help='Swap usage in MiB considered critical')
+    p.add_argument('--warning', '-w', type=int, default=1024,
+                   help='Swap usage in MiB considered warning')
+
+    args = p.parse_args()
+
+    swap = psutil.swap_memory().used
+    swap = int(swap / (1024 * 1024))  # convert to MiB
+    if swap >= args.critical:
+        print('CRITICAL - swap {} MiB >= {} MiB'.format(swap, args.critical))
+        sys.exit(2)
+    if swap >= args.warning:
+        print('WARNING - swap {} MiB >= {} MiB'.format(swap, args.warning))
+        sys.exit(1)
+    print('OK - swap {} MiB'.format(swap))
+
+
+if __name__ == '__main__':
+    main()

--- a/nixos/modules/flyingcircus/packages/fcsensuplugins/setup.py
+++ b/nixos/modules/flyingcircus/packages/fcsensuplugins/setup.py
@@ -27,6 +27,7 @@ setup(
             'check_cpu_steal=fc.sensuplugins.cpu:main',
             'check_journal=fc.sensuplugins.journal:main',
             'check_journal_file=fc.sensuplugins.journalfile:main',
+            'check_swap_abs=fc.sensuplugins.swap:main',
             'check_writable=fc.sensuplugins.writable:main'
         ],
     },

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -170,6 +170,18 @@ in {
           description = ''Limit of load thresholds before reaching critical.'';
         };
       };
+      expectedSwap = {
+        warning = mkOption {
+          type = types.str;
+          default = "1024";
+          description = ''Limit of swap usage in MiB before warning.'';
+        };
+        critical = mkOption {
+          type = types.str;
+          default = "2048";
+          description = ''Limit of swap usage in MiB before reaching critical.'';
+        };
+      };
     };
   };
 
@@ -279,7 +291,7 @@ in {
       };
       swap = {
         notification = "Swap usage is too high";
-        command = "${fcsensuplugins}/bin/check_swap_abs";
+        command = "${fcsensuplugins}/bin/check_swap_abs -w ${cfg.expectedSwap.warning} -c ${cfg.expectedSwap.critical}";
         interval = 300;
       };
       ssh = {

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -278,8 +278,8 @@ in {
         interval = 10;
       };
       swap = {
-        notification = "Swap is running low";
-        command = "check_swap -w 20% -c 10%";
+        notification = "Swap usage is too high";
+        command = "${fcsensuplugins}/bin/check_swap_abs";
         interval = 300;
       };
       ssh = {


### PR DESCRIPTION
… good idea

as all systems that we saw using more than that became unstable very soon.

This is in response to Case 100605

@flyingcircusio/release-managers

Impact:

Changelog:

* Adjust our swap check: instead of relying on relative usage and "almost empy", we now consider more than 1G of usage to be "too much". 