### PR TITLE
Remove directories where we want to put symlinks.

### DIFF
--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -169,7 +169,9 @@ in {
         PermissionsStartOnly = true;
         LimitNOFILE = "1024000";
       };
-      preStart = ''
+      preStart =
+        let rmIfDir = dir: "test -L ${dir} || (test -d ${dir} && rmdir ${dir})";
+        in ''
         ${optionalString (!config.boot.isContainer) ''
           # Only set vm.max_map_count if lower than ES required minimum
           # This avoids conflict if configured via boot.kernel.sysctl
@@ -178,6 +180,11 @@ in {
           fi
         ''}
         mkdir -m 0700 -p ${cfg.dataDir}
+        # Remove previously existing directories. Fail if they are not empty.
+        # ln -f does *not* overwrite directories
+        ${rmIfDir "${cfg.dataDir}/plugins"}
+        ${rmIfDir "${cfg.dataDir}/lib"}
+        ${rmIfDir "${cfg.dataDir}/modules"}
         # Install plugins
         ln -sfT ${esPlugins}/plugins ${cfg.dataDir}/plugins
         ln -sfT ${cfg.package}/lib ${cfg.dataDir}/lib


### PR DESCRIPTION
On existing instances there are directories, which we need to remove. They are usually empty. If not, manual intervention will be required.

Case 100722

@flyingcircusio/release-managers

Impact: 

* ElasticSearch instances will be restarted.

Changelog:

* Fix startup of existing ElasticSearch instances (#100722)
