### PR TITLE
Fix unquoted $ in multi-line string

### DIFF
--- a/nixos/modules/flyingcircus/platform/firewall.nix
+++ b/nixos/modules/flyingcircus/platform/firewall.nix
@@ -13,7 +13,7 @@ let
     import re
     import shlex
     import sys
-    R_ALLOWED = re.compile(r'^(#.*|ip[46]{0,2}tables .*)?$')
+    R_ALLOWED = re.compile(r'^(#.*|ip[46]{0,2}tables .*)?''$')
 
     for line in fileinput.input():
       line = ' '.join(


### PR DESCRIPTION
Occasionally there is the error, and the build fails:

    syntax error, unexpected $undefined, expecting IND_STR or DOLLAR_CURLY or IND_STRING_CLOSE, at /nix/store/9r68zy1vqkmiix5iccnl3sy4p65r659q-modules/flyingcircus/platform/firewall.nix:16:58

Case 100755

@flyingcircusio/release-managers

Impact:

Changelog: Fix occasional build error in firewall configuration (#100755)
