### PR TITLE
Backport Python 3.6

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -52,6 +52,8 @@ in rec {
     prometheus-haproxy-exporter
     python35
     python35Packages
+    python36
+    python36Packages
     remarshal
     ripgrep
     samba


### PR DESCRIPTION
@flyingcircusio/release-managers

Changelog:
* Add Python 3.6 
