### PR TITLE
Do not shut down if not reaching the basic target.

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
@@ -104,6 +104,8 @@ in
     ];
   };
 
+  systemd.targets.basic.unitConfig.JobTimeoutAction = "none";
+
   systemd.ctrl-alt-del = "poweroff.target";
   systemd.extraConfig = ''
     RuntimeWatchdogSec=60


### PR DESCRIPTION
As we do this all the time we've seen that stressed systems may
erroneously decide to power down (this _does_ help to resolve the
stress but we really don't like arbitrary reboots and rather solve
them directly.)

Fixes Case 100612

@flyingcircusio/release-managers 

Impact:

Changelog:
