### PR TITLE
28022 Security update for libvorbis.

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -42,6 +42,7 @@ in rec {
     iptables
     kibana
     libreoffice-fresh
+    libvorbis
     mailutils
     nix
     nodejs-4_x


### PR DESCRIPTION
Fixes #28022

@flyingcircusio/release-managers 

Impact:

- May restart a number of services depending on libvorbis.

- Rebuild packages that are linked against libvorbis.

Changelog:

- Security update for libvorbis #28022