### PR TITLE
Remove trailing \n from locally provided kibana url

### DIFF
--- a/nixos/modules/flyingcircus/roles/kibana.nix
+++ b/nixos/modules/flyingcircus/roles/kibana.nix
@@ -8,7 +8,9 @@ let
 
   elasticSearchUrl =
     if cfg.elasticSearchUrl == null
-    then (fclib.configFromFile /etc/local/kibana/elasticSearchUrl null)
+    then (
+          removeSuffix "\n"
+            (fclib.configFromFile /etc/local/kibana/elasticSearchUrl null))
     else cfg.elasticSearchUrl;
 
 


### PR DESCRIPTION
Bug id: 101014

@flyingcircusio/release-managers

Impact:

Changelog: Kibana configuration: Allow URL in /etc/local/kibana/elasticSearchUrl to be trailed by a new line (101014).