### PR TITLE
Use ghostscript from pinned 17.09 release

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -38,6 +38,8 @@ in rec {
     elasticsearch5
     firefox
     git
+    ghostscript
+    ghostscript-fonts
     graphicsmagick
     iptables
     kibana


### PR DESCRIPTION
 Case 29164

@flyingcircusio/release-managers

Changelog:
- Update Ghostscript to 9.22