### PR TITLE
Fix rabbitmq role in vagrant

### DIFF
--- a/nixos/modules/flyingcircus/roles/rabbitmq.nix
+++ b/nixos/modules/flyingcircus/roles/rabbitmq.nix
@@ -11,7 +11,7 @@ let
   # Derive password for telegraf.
   telegrafPassword = builtins.hashString
     "sha256" (concatStrings [
-      config.flyingcircus.enc.parameters.directory_password
+      (attrByPath [ "directory_password" ] "" config.flyingcircus.enc.parameters)
       config.networking.hostName
       "telegraf"
     ]);


### PR DESCRIPTION
In vagrant there is no ENC, hence the telegraf password could not be calculated. Just use empty string in this case.

Bug Id: 101170

@flyingcircusio/release-managers

Impact:

Changelog: 

* Fix RabbitMQ role in Vagrant VMs (#101170)
