### PR TITLE
101119 update apache php

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -21,8 +21,8 @@ let
   pkgs_17_09_src = (import <nixpkgs> {}).fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "ea0c4b5";
-    sha256 = "0qi1baliz6x88nzjrsyka6qbkxliry5vngmyk81hqza1863dqiwj";
+    rev = "e984f9e";
+    sha256 = "10sbyna5p03x7h6mc5cfl4dh8cd2ah4n8zxqnlm6asbjrr6n8xs7";
   };
   pkgs_17_09 = import pkgs_17_09_src {};
 
@@ -32,13 +32,14 @@ in rec {
   # === Imports from newer upstream versions ===
 
   inherit (pkgs_17_09)
+    apacheHttpd
     audiofile
     bundlerApp
     elasticsearch2
     elasticsearch5
     firefox
-    git
     ghostscript
+    git
     graphicsmagick
     iptables
     jbig2dec
@@ -56,12 +57,14 @@ in rec {
     python35Packages
     python36
     python36Packages
+    qt4
     remarshal
     ripgrep
     samba
     strongswan
     subversion18
     virtualbox
+    wkhtmltopdf
     xulrunner;
 
   libtiff = mergeOutputs [ "out" "bin" "dev" ] pkgs_17_09.libtiff;
@@ -212,6 +215,7 @@ in rec {
     php55
     php56
     php70;
+  php = php70;
 
   postfix = pkgs.callPackage ./postfix/3.0.nix { };
   powerdns = pkgs.callPackage ./powerdns.nix { };

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -50,7 +50,11 @@ in rec {
     nodejs-4_x
     nodejs-6_x
     nodejs-8_x
+    php56
+    php70
     php70Packages
+    php71
+    php71Packages
     prometheus
     prometheus-haproxy-exporter
     python35
@@ -212,10 +216,7 @@ in rec {
   rum = pkgs.callPackage ./postgresql/rum { postgresql = postgresql96; };
 
   inherit (pkgs.callPackages ./php { })
-    php55
-    php56
-    php70;
-  php = php70;
+    php55;
 
   postfix = pkgs.callPackage ./postfix/3.0.nix { };
   powerdns = pkgs.callPackage ./powerdns.nix { };

--- a/nixos/modules/flyingcircus/packages/php/default.nix
+++ b/nixos/modules/flyingcircus/packages/php/default.nix
@@ -288,15 +288,4 @@ in {
     version = "5.5.38";
     sha256 = "0f1y76whg6yx9a18mh97f8yq8lb64ri1f0zfr9la9374nbmq2g27";
   };
-
-  php56 = generic {
-    version = "5.6.35";
-    sha256 = "14ivsxdny0s7qm9pf773pafs8xzlzzpmaz039lwymn11rblsfy7f";
-  };
-
-  php70 = generic {
-    version = "7.0.29";
-    sha256 = "1g1z1nhnmq0idsb9rfb46cdddfimaacw3yal291i2ypzqpal54cq";
-  };
-
 }

--- a/nixos/modules/flyingcircus/packages/php/default.nix
+++ b/nixos/modules/flyingcircus/packages/php/default.nix
@@ -28,7 +28,7 @@ let
         # SAPI modules:
 
         apxs2 = {
-          configureFlags = ["--with-apxs2=${apacheHttpd}/bin/apxs"];
+          configureFlags = ["--with-apxs2=${apacheHttpd.dev}/bin/apxs"];
           buildInputs = [apacheHttpd];
         };
 
@@ -290,13 +290,13 @@ in {
   };
 
   php56 = generic {
-    version = "5.6.31";
-    sha256 = "03xixkvfp64bqp97p8vlj3hp63bpjw7hc16b7fgm7w35rdlp2fcg";
+    version = "5.6.35";
+    sha256 = "14ivsxdny0s7qm9pf773pafs8xzlzzpmaz039lwymn11rblsfy7f";
   };
 
   php70 = generic {
-    version = "7.0.24";
-    sha256 = "06fgpljz6xpxxkpf4cv9rqz8g504l9ikbw5aq0hqh5sgd611kycv";
+    version = "7.0.29";
+    sha256 = "1g1z1nhnmq0idsb9rfb46cdddfimaacw3yal291i2ypzqpal54cq";
   };
 
 }

--- a/nixos/modules/flyingcircus/tests/phpzts.nix
+++ b/nixos/modules/flyingcircus/tests/phpzts.nix
@@ -21,10 +21,12 @@ import ../../../tests/make-test.nix ({ lib, pkgs, ... }:
     let
       php56 = (pkgs.php56.override { config.php.zts = true; });
       php70 = (pkgs.php70.override { config.php.zts = true; });
+      php71 = (pkgs.php71.override { config.php.zts = true; });
     in
     ''
       startAll;
-      $machine->succeed("${php56}/bin/php -i | grep no-debug-zts >/dev/console");
-      $machine->succeed("${php70}/bin/php -i | grep no-debug-zts >/dev/console");
+      $machine->succeed("${php56}/bin/php -i | grep 'Thread Safety => enabled' >/dev/console");
+      $machine->succeed("${php70}/bin/php -i | grep 'Thread Safety => enabled' >/dev/console");
+      $machine->succeed("${php71}/bin/php -i | grep 'Thread Safety => enabled' >/dev/console");
     '';
 })

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -407,7 +407,7 @@ let
         ([ mainCfg.phpOptions ] ++ (map (svc: svc.phpOptions) allSubservices));
     }
     ''
-      cat ${php}/etc/php-recommended.ini > $out
+      cat ${php}/etc/php.ini > $out
       echo "$options" >> $out
     '';
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: The Apache webserver will be restarted.

Changelog:

* Update Apache to 2.4.33
* Update PHP to: 5.6.34, 7.0.28, 7.1.15
* Update Firefox to 59.0.2
* Update qt4 to 4.8.7

