### PR TITLE
Add swapfile for vagrant boxes by default.

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/vagrant/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/vagrant/default.nix
@@ -76,4 +76,10 @@ in
       root   ALL=(ALL) SETENV: ALL
       %wheel ALL=(ALL) NOPASSWD: ALL, SETENV: ALL
     '';
+
+  swapDevices = [
+    { device = "/var/swapfile01";
+      size = 2048; }
+  ];
+
 }


### PR DESCRIPTION
This was we can remove the custom configuration we have in each and every provision.nix.

Bug id: #101293

@flyingcircusio/release-managers

Impact:

Changelog:

* Add a 2G swapfile for Vagrant boxes (#101293)