### PR TITLE
Ctheune fix firewall startup

### DIFF
--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -216,7 +216,17 @@ in
                 RemainAfterExit = true;
               };
             })
-          (attrNames interfaces))));
+          (attrNames interfaces)))) //
+      # Some firewall scripts include hostnames and those won't run
+      # properly during initial startup when we don't have network yet.
+      # This isn't ideal either (see Case 101736) but it helps counter obvious
+      # breakage.
+      {
+        firewall.wantedBy = [ "network.target" ];
+        firewall.before = [ "network.target" ];
+        firewall.after = [ "systemd-modules-load.service"
+                           "network-local-commands.service" ];
+      };
 
     # firewall configuration: generic options
     networking.firewall.allowPing = true;

--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -86,12 +86,6 @@ let
       (user: "install -d -o ${toString user.id} -g ${get_primary_group user} -m 0755 ${user.home_directory}")
       userdata;
 
-  configure_lingering = userdata:
-    # No users should have lingering enabled
-    map
-      (user: " ${config.systemd.package}/bin/loginctl disable-linger ${user.uid}")
-      userdata;
-
   # merge a list of sets recursively
   mergeSets = listOfSets:
     if (builtins.length listOfSets) == 1 then
@@ -153,9 +147,6 @@ in
 
     system.activationScripts.fcio-homedirpermissions = lib.stringAfter [ "users" ]
       (builtins.concatStringsSep "\n" (home_dir_permissions cfg.userdata));
-
-    system.activationScripts.fcio-configure-lingering = lib.stringAfter [ "users" ]
-      (builtins.concatStringsSep "\n" (configure_lingering cfg.userdata));
 
   };
 }

--- a/nixos/modules/flyingcircus/roles/haproxy.nix
+++ b/nixos/modules/flyingcircus/roles/haproxy.nix
@@ -121,6 +121,7 @@ in
     systemd.services.prometheus-haproxy-exporter = {
       description = "Prometheus exporter for haproxy metrics";
       wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
       path = [ pkgs.haproxy ];
       script = ''
         exec ${pkgs.prometheus-haproxy-exporter}/bin/haproxy_exporter \

--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -122,8 +122,7 @@ in
 
     services.postgresql.initialScript = ./postgresql-init.sql;
     services.postgresql.dataDir = "/srv/postgresql/${version}";
-    systemd.services.postgresql.after = [ "network-interfaces.target" ];
-    systemd.services.postgresql.wants = [ "network-interfaces.target" ];
+    systemd.services.postgresql.bindsTo = [ "network-addresses-ethsrv.service" ];
 
     systemd.services.postgresql.postStart =
     let

--- a/nixos/modules/flyingcircus/services/clamav.nix
+++ b/nixos/modules/flyingcircus/services/clamav.nix
@@ -142,6 +142,9 @@ in
         description = "ClamAV virus database updater (freshclam)";
         restartTriggers = [ freshclamConfigFile ];
 
+        requires = [ "network.target" ];
+        after = [ "network.target" ];
+
         preStart = ''
           install -d -o ${clamavUser} -g ${clamavGroup} -m 0755 \
             ${runDir} ${stateDir}

--- a/nixos/modules/flyingcircus/services/kibana.nix
+++ b/nixos/modules/flyingcircus/services/kibana.nix
@@ -138,7 +138,7 @@ in {
     systemd.services.kibana = {
       description = "Kibana Service";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-interfaces.target" "elasticsearch.service" ];
+      after = [ "network.target" "elasticsearch.service" ];
       environment = { BABEL_CACHE_PATH = "${cfg.dataDir}/.babelcache.json"; };
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/kibana --config ${cfgFile}";

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -243,7 +243,7 @@ in {
 
     systemd.services.sensu-client = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-interfaces.target" ];
+      after = [ "network.target" ];
 
       path = [
         bash

--- a/nixos/modules/flyingcircus/services/telegraf.nix
+++ b/nixos/modules/flyingcircus/services/telegraf.nix
@@ -63,7 +63,7 @@ in {
     systemd.services.telegraf = {
       description = "Telegraf Agent";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-interfaces.target" ];
+      after = [ "network.target" ];
       path = [ pkgs.net_snmp ];
       serviceConfig = {
         ExecStart=''${cfg.package}/bin/telegraf ${startupOptions}'';

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -473,9 +473,12 @@ in
 
     systemd.services.firewall = {
       description = "Firewall";
-      wantedBy = [ "network-pre.target" ];
-      before = [ "network-pre.target" ];
-      after = [ "systemd-modules-load.service" ];
+      # XXX FCIO FlyingCircus: we need functioning networking.
+      # We're overriding this in our own modules but we can't
+      # fix the dependency cycle by countering mkMerge
+      # wantedBy = [ "network.target" ];
+      # before = [ "network.target" ];
+      # after = [ "systemd-modules-load.service" "network-local-co"];
 
       path = [ pkgs.iptables ] ++ cfg.extraPackages;
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

* Service restarts: PostgreSQL, haproxy, ClamAV, Kibana, Sensu (client), Telegraf

Changelog:

* Improve network dependencies and ordering during boot phase: more robust firewall setup with respect to DNS usage and delayed startup of network-based services.
* Correctly restart PostgreSQL if the ethsrv interfaces are reconfigured to ensure PostgreSQL reopens any lost listening sockets.