### PR TITLE
Fix startup ordering for external-network-services

### DIFF
--- a/nixos/modules/flyingcircus/services/vxlan-client.nix
+++ b/nixos/modules/flyingcircus/services/vxlan-client.nix
@@ -33,9 +33,9 @@ in
 
       systemd.services."network-external-routing" = rec {
         description = "Custom routing rules for external networks";
-        after = [ "network-routing-ethsrv.service" ];
+        after = [ "network-routing-ethsrv.service" "firewall.service" ];
         requires = after;
-        wantedBy = [ "network-interfaces.target" ];
+        wantedBy = [ "network.target" ];
         bindsTo = [ "sys-subsystem-net-devices-ethsrv.device" ];
         path = [ pkgs.gawk pkgs.iproute pkgs.glibc pkgs.iptables ];
 


### PR DESCRIPTION
This is a side effect of recent firewall service changes (PR#408).

Case 101785

@flyingcircusio/release-managers

Impact:

Changelog: Fix bug in startup ordering of network services (external network routing vs. firewall)
