### PR TITLE
Fix filtering of metrics for customer-specific statshosts.

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/telegraf.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/telegraf.nix
@@ -56,7 +56,7 @@ let
 
 
 in mkMerge [
-  (mkIf (params ? location && params ? resource_group) {
+  ({
 
     services.telegraf.enable = true;
     services.telegraf.configDir =

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -20,8 +20,7 @@ let
     "-storage.local.target-heap-size=${toString prometheusHeap}"
     "-storage.local.chunk-encoding-version=2"
   ];
-  prometheusListenAddress =
-    "${lib.head(fclib.listenAddressesQuotedV6 config "ethsrv")}:9090";
+  prometheusListenAddress = cfgStatsGlobal.prometheusListenAddress;
   prometheusHeap =
     (fclib.current_memory config 256) * 1024 * 1024
     * cfgStatsGlobal.prometheusHeapMemoryPercentage / 100;
@@ -169,6 +168,12 @@ in
         type = types.str;
         default = "https://github.com/flyingcircusio/grafana.git";
         description = "Dashboard git repository.";
+      };
+
+      prometheusListenAddress = mkOption {
+        type = types.str;
+        default = "${lib.head(fclib.listenAddressesQuotedV6 config "ethsrv")}:9090";
+        description = "Prometheus listen address";
       };
 
       prometheusHeapMemoryPercentage = mkOption {

--- a/nixos/modules/flyingcircus/roles/statshost/global-relabel.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/global-relabel.nix
@@ -16,7 +16,7 @@ let
       action = "labeldrop"; }
   ];
 
-in
+in mkIf config.flyingcircus.roles.statshost.enable
 {
   flyingcircus.roles.statshost.prometheusMetricRelabel =
     markAllowedMetrics ++ dropUnmarkedMetrics;

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -50,6 +50,8 @@
   rabbitmq = hydraJob (import ./rabbitmq.nix { inherit system; });
 
   sensuserver = hydraJob (import ./sensu.nix { inherit system; });
+  statshost-master = hydraJob (import ./statshost-master.nix { inherit system; });
+  statshost-global = hydraJob (import ./statshost-global.nix { inherit system; });
   systemdCycles = hydraJob (import ./systemd_cycles.nix { inherit system; });
 
   users = hydraJob (import ./users { inherit system; });

--- a/nixos/modules/flyingcircus/tests/statshost-global.nix
+++ b/nixos/modules/flyingcircus/tests/statshost-global.nix
@@ -33,16 +33,12 @@ import ../../../tests/make-test.nix ({lib, pkgs, ... }:
         192.168.101.1 myself.fcio.net myself
       '';
 
-      users.groups.login = {
-        members = [];
-      };
-
       # Add a scrape target for our test node. Globally nodes are only scraped
       # via relay/proxy, but we don't want/need to set this up here.
       environment.etc."local/statshost/scrape-test.json".text =
         builtins.toJSON [ { targets = [ "myself.fcio.net:9126" ]; } ];
-
     };
+
   testScript =
     ''
       $machine->waitForUnit("prometheus.service");

--- a/nixos/modules/flyingcircus/tests/statshost-global.nix
+++ b/nixos/modules/flyingcircus/tests/statshost-global.nix
@@ -1,0 +1,77 @@
+import ../../../tests/make-test.nix ({lib, pkgs, ... }:
+{
+  name = "statshost-global";
+  machine =
+    { config, ... }:
+    {
+      imports = [
+        ./setup.nix
+        ../platform
+        ../services
+        ../static
+        ../roles
+        ../infrastructure/fcio/telegraf.nix
+      ];
+
+      flyingcircus.roles.statshost.enable = true;
+
+      flyingcircus.enc.parameters.resource_group = "test";
+      flyingcircus.enc.parameters.interfaces.srv = {
+        bridged = false;
+        mac = "52:54:00:12:34:56";
+        networks = {
+          "192.168.101.0/24" = [ "192.168.101.1" ];
+          "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::1" ];
+        };
+        gateways = {};
+      };
+      flyingcircus.enc_addresses.srv = [
+        { name = "myself";
+          ip = "192.168.101.1"; }
+      ];
+      networking.extraHosts = ''
+        192.168.101.1 myself.fcio.net myself
+      '';
+
+      users.groups.login = {
+        members = [];
+      };
+
+      # Add a scrape target for our test node. Globally nodes are only scraped
+      # via relay/proxy, but we don't want/need to set this up here.
+      environment.etc."local/statshost/scrape-test.json".text =
+        builtins.toJSON [ { targets = [ "myself.fcio.net:9126" ]; } ];
+
+    };
+  testScript =
+    ''
+      $machine->waitForUnit("prometheus.service");
+      $machine->waitForUnit("telegraf.service");
+      $machine->waitForFile("/run/telegraf/influx.sock");
+
+      # Job for RG test created and up?
+      $machine->waitUntilSucceeds(<<'EOF');
+        curl -s http://192.168.101.1:9090/api/v1/targets | \
+          jq -e \
+          '.data.activeTargets[] |
+            select(.health == "up" and .labels.job == "test")'
+      EOF
+
+      # Index custom metric, and expect it *not* to be found in prometheus
+      # The extended sleep is necessary to wait for the scape cycle. Still it's
+      # a bit fuzzy.
+
+      $machine->succeed(<<'EOF');
+        echo my_custom_metric value=42 | \
+          ${pkgs.socat}/bin/socat - UNIX-CONNECT:/run/telegraf/influx.sock
+      EOF
+
+      $machine->sleep(16);
+      $machine->fail(<<'EOF');
+        curl -s \
+            http://192.168.101.1:9090/api/v1/query?query='my_custom_metric' | \
+         jq -e '.data.result[].value[1] == "42"'
+      EOF
+    '';
+})
+

--- a/nixos/modules/flyingcircus/tests/statshost-master.nix
+++ b/nixos/modules/flyingcircus/tests/statshost-master.nix
@@ -32,12 +32,8 @@ import ../../../tests/make-test.nix ({lib, pkgs, ... }:
       networking.extraHosts = ''
         192.168.101.1 myself.fcio.net myself
       '';
-
-      users.groups.login = {
-        members = [];
-      };
-
     };
+
   testScript =
     ''
       $machine->waitForUnit("prometheus.service");

--- a/nixos/modules/flyingcircus/tests/statshost-master.nix
+++ b/nixos/modules/flyingcircus/tests/statshost-master.nix
@@ -1,0 +1,70 @@
+import ../../../tests/make-test.nix ({lib, pkgs, ... }:
+{
+  name = "statshost-master";
+  machine =
+    { config, ... }:
+    {
+      imports = [
+        ./setup.nix
+        ../platform
+        ../services
+        ../static
+        ../roles
+        ../infrastructure/fcio/telegraf.nix
+      ];
+
+      flyingcircus.roles.statshost-master.enable = true;
+
+      flyingcircus.enc.parameters.resource_group = "test";
+      flyingcircus.enc.parameters.interfaces.srv = {
+        bridged = false;
+        mac = "52:54:00:12:34:56";
+        networks = {
+          "192.168.101.0/24" = [ "192.168.101.1" ];
+          "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::1" ];
+        };
+        gateways = {};
+      };
+      flyingcircus.enc_addresses.srv = [
+        { name = "myself";
+          ip = "192.168.101.1"; }
+      ];
+      networking.extraHosts = ''
+        192.168.101.1 myself.fcio.net myself
+      '';
+
+      users.groups.login = {
+        members = [];
+      };
+
+    };
+  testScript =
+    ''
+      $machine->waitForUnit("prometheus.service");
+      $machine->waitForUnit("telegraf.service");
+      $machine->waitForFile("/run/telegraf/influx.sock");
+
+      # Job for RG test created and up?
+      $machine->waitUntilSucceeds(<<'EOF');
+        curl -s http://192.168.101.1:9090/api/v1/targets | \
+          jq -e \
+          '.data.activeTargets[] |
+            select(.health == "up" and .labels.job == "test")'
+      EOF
+
+      # Index custom metric, and expect it to be found in prometheus after
+      # some time.
+
+      $machine->succeed(<<'EOF');
+        echo my_custom_metric value=42 | \
+          ${pkgs.socat}/bin/socat - UNIX-CONNECT:/run/telegraf/influx.sock
+      EOF
+
+      $machine->waitUntilSucceeds(<<'EOF');
+        curl -s \
+            http://192.168.101.1:9090/api/v1/query?query='my_custom_metric' | \
+         jq -e '.data.result[].value[1] == "42"'
+      EOF
+    '';
+})
+


### PR DESCRIPTION
* Only the global relay is filtering now.
* There are tests for both cases which can be extended to test futher functionality.

Bug id: #101607

@flyingcircusio/release-managers

Impact:

Changelog: Fix filtering of metrics for customer-specific statshosts (#101607)