### PR TITLE
Use ES5 for Loghost

### DIFF
--- a/nixos/modules/flyingcircus/roles/loghost.nix
+++ b/nixos/modules/flyingcircus/roles/loghost.nix
@@ -51,7 +51,7 @@ in
       ];
     };
 
-    flyingcircus.roles.elasticsearch2.enable = true;
+    flyingcircus.roles.elasticsearch5.enable = true;
     flyingcircus.roles.elasticsearch = {
       dataDir = "/var/lib/elasticsearch";
       clusterName = "graylog";


### PR DESCRIPTION
Bugs id #101899

@flyingcircusio/release-managers

Impact:

Changelog: Update Loghosts to use to ElasticSearch 5 (#101899)
