### PR TITLE
103210 update haproxy

### DIFF
--- a/nixos/modules/flyingcircus/roles/haproxy.nix
+++ b/nixos/modules/flyingcircus/roles/haproxy.nix
@@ -75,8 +75,8 @@ in
 
    # FCIO
     systemd.services.haproxy = let
-      haproxy_ = "${pkgs.haproxy}/sbin/haproxy-systemd-wrapper -f /etc/current-config/haproxy.cfg -p /run/haproxy.pid";
-      verifyConfig = "${pkgs.haproxy}/sbin/haproxy -c -q -f /etc/current-config/haproxy.cfg";
+      haproxy_ = "${pkgs.haproxy}/bin/haproxy -f /etc/current-config/haproxy.cfg -p /run/haproxy.pid -Ws";
+      verifyConfig = "${pkgs.haproxy}/bin/haproxy -c -q -f /etc/current-config/haproxy.cfg";
       in {
       reloadIfChanged = true;
       restartTriggers = [ haproxyCfg ];

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,21 +1,57 @@
-{ stdenv, pkgs, fetchurl, openssl }:
+{ useLua ? !stdenv.isDarwin
+, usePcre ? true
+, stdenv, fetchurl, fetchpatch
+, openssl, zlib, lua5_3 ? null, pcre ? null
+}:
+
+assert useLua -> lua5_3 != null;
+assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
-  majorVersion = "1.5";
-  version = "${majorVersion}.14";
-  name = "haproxy-${version}";
+  pname = "haproxy";
+  version = "1.8.9";
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://haproxy.1wt.eu/download/${majorVersion}/src/${name}.tar.gz";
-    sha256 = "16cg1jmy2d8mq2ypwifsvhbyp4pyrj0zm0r818sx0r4hchwdsrcm";
+    url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
+    sha256 = "00miblgwll3mycsgmp3gd3cn4lwsagxzgjxk5i6csnyqgj97fss3";
   };
 
-  buildInputs = [ openssl ];
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-11469.patch";
+      url = "https://git.haproxy.org/?p=haproxy-1.8.git;a=patch;h=17514045e5d934dede62116216c1b016fe23dd06";
+      sha256 = "0hzcvghg8qz45n3mrcgsjgvrvicvbvm52cc4hs5jbk1yb50qvls7";
+    })
+  ] ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
+    name = "fix-darwin-no-threads-build.patch";
+    url = "https://git.haproxy.org/?p=haproxy-1.8.git;a=patch;h=fbf09c441a4e72c4a690bc7ef25d3374767fe5c5;hp=3157ef219c493f3b01192f1b809a086a5b119a1e";
+    sha256 = "16ckzb160anf7xih7mmqy59pfz8sdywmyblxnr7lz9xix3jwk55r";
+  });
 
-  # TODO: make it work on darwin/bsd as well
-  preConfigure = ''
-    export makeFlags="TARGET=linux2628 PREFIX=$out USE_OPENSSL=yes"
-  '';
+  buildInputs = [ openssl zlib ]
+    ++ stdenv.lib.optional useLua lua5_3
+    ++ stdenv.lib.optional usePcre pcre;
+
+  # TODO: make it work on bsd as well
+  makeFlags = [
+    "PREFIX=\${out}"
+    ("TARGET=" + (if stdenv.isSunOS  then "solaris"
+             else if stdenv.isLinux  then "linux2628"
+             else if stdenv.isDarwin then "osx"
+             else "generic"))
+  ];
+  buildFlags = [
+    "USE_OPENSSL=yes"
+    "USE_ZLIB=yes"
+  ] ++ stdenv.lib.optionals usePcre [
+    "USE_PCRE=yes"
+    "USE_PCRE_JIT=yes"
+  ] ++ stdenv.lib.optionals useLua [
+    "USE_LUA=yes"
+    "LUA_LIB=${lua5_3}/lib"
+    "LUA_INC=${lua5_3}/include"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc";
 
   meta = {
     description = "Reliable, high performance TCP/HTTP load balancer";
@@ -28,8 +64,8 @@ stdenv.mkDerivation rec {
       hardware.
     '';
     homepage = http://haproxy.1wt.eu;
-    maintainers = [ stdenv.lib.maintainers.garbas ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ fuzzy-id garbas ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     license = stdenv.lib.licenses.gpl2;
   };
 }

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -2,6 +2,7 @@
 , usePcre ? true
 , stdenv, fetchurl, fetchpatch
 , openssl, zlib, lua5_3 ? null, pcre ? null
+, systemd  # FCIO
 }:
 
 assert useLua -> lua5_3 != null;
@@ -9,11 +10,12 @@ assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
-  version = "1.8.9";
+  majorVersion = "1.8";
+  version = "${majorVersion}.9";
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
+    url = "https://www.haproxy.org/download/${majorVersion}/src/${name}.tar.gz";
     sha256 = "00miblgwll3mycsgmp3gd3cn4lwsagxzgjxk5i6csnyqgj97fss3";
   };
 
@@ -29,7 +31,7 @@ stdenv.mkDerivation rec {
     sha256 = "16ckzb160anf7xih7mmqy59pfz8sdywmyblxnr7lz9xix3jwk55r";
   });
 
-  buildInputs = [ openssl zlib ]
+  buildInputs = [ openssl zlib systemd ]  # FCIO
     ++ stdenv.lib.optional useLua lua5_3
     ++ stdenv.lib.optional usePcre pcre;
 
@@ -44,6 +46,7 @@ stdenv.mkDerivation rec {
   buildFlags = [
     "USE_OPENSSL=yes"
     "USE_ZLIB=yes"
+    "USE_SYSTEMD=yes"  # FCIO
   ] ++ stdenv.lib.optionals usePcre [
     "USE_PCRE=yes"
     "USE_PCRE_JIT=yes"


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact: 

* HAProxy instances will be restarted.

Changelog:

* Update HAProxy 1.5.14 → 1.8.9 (#103210)