### PR TITLE
Fix build of PHP 5.6 packages

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -51,6 +51,7 @@ in rec {
     nodejs-6_x
     nodejs-8_x
     php56
+    php56Packages
     php70
     php70Packages
     php71
@@ -223,6 +224,7 @@ in rec {
 
   inherit (pkgs.callPackages ./php { })
     php55;
+  phpPackages = php56Packages;
 
   postfix = pkgs.callPackage ./postfix/3.0.nix { };
   powerdns = pkgs.callPackage ./powerdns.nix { };

--- a/nixos/release-flyingcircus.nix
+++ b/nixos/release-flyingcircus.nix
@@ -80,12 +80,12 @@ let
       openvpn
       osm2pgsql
       osrm-backend
-      phpPackages.xcache
       qt4
       ssmtp
       pdf2svg
       wkhtmltopdf
       ;
+    inherit (php56Packages) xcache;
   };
 
   # List of package names for Python packages defined in modules/flyingcircus

--- a/nixos/release-flyingcircus.nix
+++ b/nixos/release-flyingcircus.nix
@@ -80,6 +80,7 @@ let
       openvpn
       osm2pgsql
       osrm-backend
+      phpPackages.xcache
       qt4
       ssmtp
       pdf2svg


### PR DESCRIPTION
Bugs id #103319

@flyingcircusio/release-managers

Impact:

Changelog: 

* Fix building of PHP 5.6 packages, like xcache (#103319)
