### PR TITLE
Update our 17.09 upstream for security releases: git, libtiff

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -21,8 +21,8 @@ let
   pkgs_17_09_src = (import <nixpkgs> {}).fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "159b63a";
-    sha256 = "03hy1hlgk1h7bmgjmprc55s3nr635kznzvmspspwqw9xb2b2xcfq";
+    rev = "0d856d8";
+    sha256 = "0pqsk61kkzqqb79jp5rhn7ay5ld7h02hd8nas23qn6ibp1mv7aa1";
   };
   pkgs_17_09 = import pkgs_17_09_src {};
 


### PR DESCRIPTION
Includes:

- #101123 libtiff
- #101837 git
- (no ticket but probably applicable) utillinux

@flyingcircusio/release-managers

Impact:

Changelog:

- Security update for libtiff (#101123)
- Security update for git (#101837)