### PR TITLE
Update OpenSSL: 1.0.2o, 1.1.0h

### DIFF
--- a/nixos/modules/flyingcircus/packages/openssl/default.nix
+++ b/nixos/modules/flyingcircus/packages/openssl/default.nix
@@ -105,14 +105,14 @@ in {
 
   openssl_1_0_2 = common {
     version = "1.0.2";
-    release = "n";
-    sha256 = "1zm82pyq5a9jm10q6iv7d3dih3xwjds4x30fqph3k317byvsn2rp";
+    release = "o";
+    sha256 = "0kcy13l701054nhpbd901mz32v1kn4g311z0nifd83xs2jbmqgzc";
   };
 
   openssl_1_1_0 = common {
     version = "1.1.0";
-    release = "g";
-    sha256 = "1zm82pyq5a9jm10q6iv7d3dih3xwjds4x30fqph3k317byvsn2rp";
+    release = "h";
+    sha256 = "05x509lccqjscgyi935z809pwfm708islypwhmjnb6cyvrn64daq";
   };
 
 }


### PR DESCRIPTION
Fixes #100885

@flyingcircusio/release-managers

Impact:

* Restart of many services depending on OpenSSL.

Changelog:

* Security update for OpenSSL: 1.0.2o, 1.1.0h (#100885)
