### PR TITLE
Security update for vim: 8.0.1451

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -45,7 +45,8 @@ in rec {
   inherit (pkgs_18_03)
     nodejs-6_x
     nodejs-8_x
-    nodejs-9_x;
+    nodejs-9_x
+    vim;
 
   inherit (pkgs_17_09)
     apacheHttpd


### PR DESCRIPTION
Fixes #101782

@flyingcircusio/release-managers

Impact:

Changelog:

- Security update for vim: 8.0.1451 (#101782)