### PR TITLE
Set varnish-service to restart always 

### DIFF
--- a/nixos/modules/flyingcircus/roles/webproxy.nix
+++ b/nixos/modules/flyingcircus/roles/webproxy.nix
@@ -81,6 +81,9 @@ in
 
       serviceConfig = {
         ExecStart = (lib.mkOverride 99 varnish_);
+        Restart = "on-failure";
+        RestartSec = "1s";
+        StartLimitInterval = "1min";
       };
     };
 

--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -48,8 +48,13 @@ with lib;
         chown -R varnish:varnish ${cfg.stateDir}
       '';
       path = [ pkgs.gcc ];
-      serviceConfig.ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -u varnish";
-      serviceConfig.Type = "forking";
+      serviceConfig = {
+        ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -u varnish";
+        Restart = "always";
+        RestartSec = "10s";
+        StartLimitInterval = "1min";
+        Type = "forking";
+      };
     };
 
     environment.systemPackages = [ pkgs.varnish ];

--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -48,13 +48,8 @@ with lib;
         chown -R varnish:varnish ${cfg.stateDir}
       '';
       path = [ pkgs.gcc ];
-      serviceConfig = {
-        ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -u varnish";
-        Restart = "always";
-        RestartSec = "10s";
-        StartLimitInterval = "1min";
-        Type = "forking";
-      };
+      serviceConfig.ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -u varnish";
+      serviceConfig.Type = "forking";
     };
 
     environment.systemPackages = [ pkgs.varnish ];


### PR DESCRIPTION
Goal is to ensure it's tried to be restarted after initial failure where unit entered failed state. This does not address varnish internal errors like VCL-issues

Case 103578

@flyingcircusio/release-managers