### PR TITLE
Backport bazaar 2.7.0 from 18.03

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -43,6 +43,7 @@ in rec {
   # === Imports from newer upstream versions ===
 
   inherit (pkgs_18_03)
+    bazaar
     nodejs-6_x
     nodejs-8_x
     nodejs-9_x


### PR DESCRIPTION
This package includes also a patch for CVE-2017-14176

Case 101135

@flyingcircusio/release-managers

Changelog: Update bazaar to 2.7.0
