### PR TITLE
Allow graylog.extraConfig lines in local.nix

### DIFF
--- a/nixos/modules/flyingcircus/roles/graylog.nix
+++ b/nixos/modules/flyingcircus/roles/graylog.nix
@@ -322,10 +322,11 @@ in
             slack
           ];
         extraConfig = let
+            slash = addr: if fclib.isIp4 addr then "/32" else "/128";
             trustedProxies =
               concatStringsSep ", " (
                 map
-                  (a: "${fclib.stripNetmask a.ip}/${if fclib.isIp4 a.ip then "32" else "128"}")
+                  (a: (fclib.stripNetmask a.ip) + (slash a.ip))
                   (filter
                     (a: builtins.elem "${a.name}.${config.networking.domain}" glNodes)
                     config.flyingcircus.enc_addresses.srv));

--- a/nixos/modules/flyingcircus/services/graylog.nix
+++ b/nixos/modules/flyingcircus/services/graylog.nix
@@ -149,7 +149,7 @@ in
       };
 
       extraConfig = mkOption {
-        type = types.str;
+        type = types.lines;
         default = "";
         description = "Any other configuration options you might want to add";
       };


### PR DESCRIPTION
By changing the type of services.graylog.extraConfig from types.str to
types.lines, additional lines can be appended by assigning to this
option in multiple places.

Case 103344

@flyingcircusio/release-managers

Impact:

Changelog: Allow `services.graylog.extraConfig` to be set from local.nix
