### PR TITLE
Configure statshost firewalls via IPs instead of names

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/telegraf.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/telegraf.nix
@@ -107,12 +107,13 @@ in mkMerge [
     };
 
     networking.firewall.extraCommands =
-      let
-        statsHost = fclib.listServiceAddress config "statshostproxy-collector";
-      in optionalString (statsHost != null) ''
-        ip46tables -A nixos-fw -i ethsrv -s ${statsHost} \
-          -p tcp --dport ${port} -j nixos-fw-accept
-      '';
+      "# fcio/telegraf\n" + (concatStringsSep ""
+        (map
+          (ip: ''
+            ${fclib.iptables ip} -A nixos-fw -i ethsrv -s ${ip} \
+              -p tcp --dport ${port} -j nixos-fw-accept
+          '')
+          (fclib.listServiceIPs config "statshostproxy-collector")));
 
     flyingcircus.roles.statshost.prometheusMetricRelabel =
       let

--- a/nixos/modules/flyingcircus/lib/network.nix
+++ b/nixos/modules/flyingcircus/lib/network.nix
@@ -56,6 +56,15 @@ rec {
       (s: s.service == service)
       config.flyingcircus.enc_services));
 
+  listServiceIPs = config: service:
+  (lib.flatten
+    (map
+      (service: service.ips)
+      (filter
+        (s: s.service == service)
+        config.flyingcircus.enc_services)));
+
+
   # Return service address (string) or null, if no service
   listServiceAddress = config: service:
     let


### PR DESCRIPTION
Bugs id: #104851

@flyingcircusio/release-managers

Impact:

Changelog: To improve stability, configure statshost related firewall settings with IP addresses instead of names (#104851)
