### PR TITLE
105028 Update php to more recent versions

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -49,6 +49,8 @@ in rec {
     nodejs-6_x
     nodejs-8_x
     nodejs-9_x
+    php56
+    php56Packages
     pipenv
     vim;
 

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -55,6 +55,8 @@ in rec {
     php70Packages
     php71
     php71Packages
+    php72
+    php72Packages
     pipenv
     vim;
 

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -53,6 +53,8 @@ in rec {
     php56Packages
     php70
     php70Packages
+    php71
+    php71Packages
     pipenv
     vim;
 

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -51,6 +51,8 @@ in rec {
     nodejs-9_x
     php56
     php56Packages
+    php70
+    php70Packages
     pipenv
     vim;
 

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -79,12 +79,6 @@ in rec {
     mailutils
     nix
     nodejs-4_x
-    php56
-    php56Packages
-    php70
-    php70Packages
-    php71
-    php71Packages
     prometheus
     prometheus-haproxy-exporter
     python35


### PR DESCRIPTION
@flyingcircusio/release-managers

Case 105028

Impact:
* Apache with mod_php enabled will be restarted

Changelog:
* Update PHP 5.6.34 -> 5.6.36
* Update PHP 7.0.28 -> 7.0.30
* Update PHP 7.1.15 -> 7.1.19
* Add PHP 7.2.