### PR TITLE
Backport shadow from 18.03

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -50,6 +50,7 @@ in rec {
     nodejs-8_x
     nodejs-9_x
     pipenv
+    shadow
     vim;
 
   inherit (pkgs_17_09)


### PR DESCRIPTION
@flyingcircusio/release-managers
This PR updates shadow to version currently inside 18.03 -- 4.5 

Impact:
* Restarts services depending on shadow -- e.g. PostgreSQL

Changelog:
* Update shadow to 4.5
