### PR TITLE
Backport OpenVPN from 18.03

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -49,6 +49,7 @@ in rec {
     nodejs-6_x
     nodejs-8_x
     nodejs-9_x
+    openvpn
     pipenv
     vim;
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:
* Restart OpenVPN 

Changelog:
* Updates OpenVPN to 2.4.4 (incl. updates of dependencies)

Case 102038