### PR TITLE
Give Prometheus more time for shutting down.

### DIFF
--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -371,6 +371,11 @@ in
     # An actual statshost. Enable Prometheus.
     (mkIf (cfgStatsGlobal.enable || cfgStatsRG.enable) {
 
+      systemd.services.prometheus.serviceConfig = {
+        # Prometheus can take a few minutes to shut down. If it is forcefully
+        # killed, a crash recovery process is started, which takes even longer.
+        TimeoutStopSec = "10m";
+      };
       services.prometheus.enable = true;
       services.prometheus.extraFlags = promFlags;
       services.prometheus.listenAddress = prometheusListenAddress;


### PR DESCRIPTION
Bugs id #105074

@flyingcircusio/release-managers

Impact:

Changelog: Give Prometheus more time when shutting down. Before Prometheus was killed after 30s which causes a lengthy crash recovery when starting (#105074)
