### PR TITLE
Update bundix 1.0.2->1.0.3

### DIFF
--- a/pkgs/development/interpreters/ruby/bundix/gemset.nix
+++ b/pkgs/development/interpreters/ruby/bundix/gemset.nix
@@ -1,11 +1,11 @@
 {
   "bundix" = {
-    version = "1.0.2";
+    version = "1.0.3";
     source = {
       type = "git";
       url = "https://github.com/cstrahan/bundix.git";
       rev = "c879cf901ff8084b4c97aaacfb5ecbdb0f95cc03";
-      sha256 = "05kmdnq4qa5h8l3asv05cjpnyplnqqx6hrqybj2cjlzmdxnkkgyj";
+      sha256 = "1kxxx7f5dwk9p5l8cidp6y220zclql4cmk0958ykh41b0x6grgab";
       fetchSubmodules = false;
     };
     dependencies = [


### PR DESCRIPTION
Case 105196

This PR updates bundix to 1.0.3 and fixes the used checksum 

@flyingcircusio/release-managers

Changelog:
* Update bundix to 1.0.2