### PR TITLE
Update Oracle Java 8 to 181

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "65";
+  patchVersion = "181";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1shri8mw648piivyparbpzskiq4i0z6kain9kr7ylav5mv7h66fg";
-  sha256_x86_64 = "1rr6g2sb0f1vyf3l9nvj49ah28bsid92z0lj9pfjlb12vjn2mnw8";
+  sha256_i686 = "5e2d3c0808480de058ad7b114113d029a76fa406f9402ae4d82555247473d3bb   ";
+  sha256_x86_64 = "1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
Bugs id: #105232

@flyingcircusio/release-managers

Impact:

Changelog: Update Oracle Java 8 to Patch 181 (#105232)
