### PR TITLE
Set retry time for Apache startup to 1min

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -692,6 +692,7 @@ in
         serviceConfig.PIDFile = "${mainCfg.stateDir}/httpd.pid";
         serviceConfig.Restart = "always";
         serviceConfig.RestartSec = "5s";
+        serviceConfig.StartLimitInterval = "1min";
       };
 
   };


### PR DESCRIPTION
Case 105206

@flyingcircusio/release-managers

Impact:
* sytemd-unit of Apache will be reloaded

Changelog:
* Prevent Apache from init restarts in case of an error