### PR TITLE
Use Apache from 18.03

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -45,6 +45,7 @@ in rec {
   # === Imports from newer upstream versions ===
 
   inherit (pkgs_18_03)
+    apacheHttpd
     bazaar
     nodejs-6_x
     nodejs-8_x
@@ -62,7 +63,6 @@ in rec {
     vim;
 
   inherit (pkgs_17_09)
-    apacheHttpd
     audiofile
     buildBowerComponents
     bundlerApp


### PR DESCRIPTION
Case 105166

This PR ensures we are using Apache as well as PHP from 18.03 branch to avoid issues with mod_php 

@flyingcircusio/release-managers

Impact:
* Apache will be restarted
