### PR TITLE
Increase maximum network receive buffer size

### DIFF
--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -244,6 +244,7 @@ in
       # work around CVE-2016-5696
       # obsolete on Linux 4.7+
       "net.ipv4.tcp_challenge_ack_limit" = "999999999";
+      "net.core.rmem_max" = 8388608;
     };
   };
 }

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -280,7 +280,7 @@ in
         ];
       };
 
-      boot.kernel.sysctl."net.core.rmem_max" = 8388608;
+      boot.kernel.sysctl."net.core.rmem_max" = lib.mkOverride 90 25165824;
 
       services.collectdproxy.statshost.enable = true;
       services.collectdproxy.statshost.send_to =


### PR DESCRIPTION
Now rmem_max is generally set to 8M and to 24M on the central statshost.
This is believed to reduce drop outs in telemetry data.

Case 105227

@flyingcircusio/release-managers

Impact:

Changelog: Reduce drop-outs of telemetry data by enlarging network receive buffers
