### PR TITLE
Fix gaps in prometheus metrics on central statshost

### DIFF
--- a/nixos/modules/flyingcircus/roles/statshost/location-relay.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/location-relay.nix
@@ -32,7 +32,6 @@ in
         location / {
             resolver ${concatStringsSep " " config.networking.nameservers};
             proxy_pass http://$http_host$request_uri$is_args$args;
-            proxy_bind ${head (fclib.listenAddresses config "ethsrv")};
         }
       }
     '';


### PR DESCRIPTION
Nginx proxy was bound to a fixed address (usually ipv4). When a v6 address was chosen to connect to this fails. The proxy_bind is no longer necessary, as the bug in telegraf was fixed quite some time ago. (messed up output for second prometheus output)

bugs id #106553

@flyingcircusio/release-managers

Impact:

Changelog: Fix metric gaps on central statshost (#106553)
