### PR TITLE
105414 update prometheus downsample influx

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -34,8 +34,6 @@ let
   };
   pkgs_18_03 = import pkgs_18_03_src {};
 
-  # Please leave the double import in place (the channel build will fail
-  # otherwise).
   pkgs_17_09_src = (import <nixpkgs> {}).fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";

--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -47,16 +47,17 @@ let
 in rec {
 
   # Important: register these sources in platform/garbagecollect/default.nix!
-  inherit pkgs_17_09_src;
-  inherit pkgs_18_03_src;
   inherit pkgs_18_09_src;
+  inherit pkgs_18_03_src;
+  inherit pkgs_17_09_src;
 
   # === Imports from newer upstream versions ===
 
   inherit (pkgs_18_09)
     chromium
     chromedriver
-    nodejs-10_x;
+    nodejs-10_x
+    prometheus-haproxy-exporter;
 
   inherit (pkgs_18_03)
     apacheHttpd
@@ -95,8 +96,6 @@ in rec {
     mailutils
     nix
     nodejs-4_x
-    prometheus
-    prometheus-haproxy-exporter
     python35
     python35Packages
     python36
@@ -273,6 +272,13 @@ in rec {
   postfix = pkgs.callPackage ./postfix/3.0.nix { };
   powerdns = pkgs.callPackage ./powerdns.nix { };
   prometheus-elasticsearch-exporter = pkgs_17_09.callPackage ./prometheus-elasticsearch-exporter.nix { };
+
+  inherit (pkgs_18_09.callPackage ./prometheus {
+    buildGoPackage = pkgs_18_09.buildGo110Package;
+  })
+    prometheus_1
+    prometheus_2
+    ;
 
   qemu = pkgs.callPackage ./qemu/qemu-2.8.nix {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices Cocoa;

--- a/nixos/modules/flyingcircus/packages/prometheus/default.nix
+++ b/nixos/modules/flyingcircus/packages/prometheus/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, go, buildGoPackage, fetchFromGitHub }:
+
+let
+  goPackagePath = "github.com/prometheus/prometheus";
+
+  generic = { version, sha256, ... }@attrs:
+    let attrs' = builtins.removeAttrs attrs ["version" "sha256"]; in
+      buildGoPackage ({
+        name = "prometheus-${version}";
+
+        inherit goPackagePath;
+
+        src = fetchFromGitHub {
+          rev = "v${version}";
+          owner = "prometheus";
+          repo = "prometheus";
+          inherit sha256;
+        };
+
+        doCheck = true;
+
+        buildFlagsArray = let t = "${goPackagePath}/vendor/github.com/prometheus/common/version"; in ''
+          -ldflags=
+             -X ${t}.Version=${version}
+             -X ${t}.Revision=unknown
+             -X ${t}.Branch=unknown
+             -X ${t}.BuildUser=nix@nixpkgs
+             -X ${t}.BuildDate=unknown
+             -X ${t}.GoVersion=${stdenv.lib.getVersion go}
+        '';
+
+        preInstall = ''
+          mkdir -p "$bin/share/doc/prometheus" "$bin/etc/prometheus"
+          cp -a $src/documentation/* $bin/share/doc/prometheus
+          cp -a $src/console_libraries $src/consoles $bin/etc/prometheus
+        '';
+
+        meta = with stdenv.lib; {
+          description = "Service monitoring system and time series database";
+          homepage = https://prometheus.io;
+          license = licenses.asl20;
+          maintainers = with maintainers; [ benley fpletz ];
+          platforms = platforms.unix;
+        };
+    } // attrs');
+in rec {
+  prometheus_1 = generic {
+    version = "1.8.2";
+    sha256 = "088flpg3qgnj9afl9vbaa19v2s1d21yxy38nrlv5m7cxwy2pi5pv";
+  };
+
+  prometheus_2 = generic {
+    version = "2.4.2";
+    sha256 = "1axxpkqyvwprjpqqpcf8avhbmglh673m4sly8xkgkrn4qzrix0r5";
+  };
+}

--- a/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
+++ b/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
@@ -76,9 +76,9 @@ in {
         # The following store paths will be needed on every evaluation but are
         # not referenced anywhere else. We mention them here to protect them
         # from garbage collection.
-        ${pkgs.pkgs_17_09_src}
-        ${pkgs.pkgs_18_03_src}
         ${pkgs.pkgs_18_09_src}
+        ${pkgs.pkgs_18_03_src}
+        ${pkgs.pkgs_17_09_src}
       '';
     }
 

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -442,7 +442,6 @@ in
 
       services.influxdb.enable = true;
       services.influxdb.dataDir = "/srv/influxdb";
-      systemd.services.influxdb.serviceConfig.LimitNOFILE = "60000";
       services.influxdb.extraConfig = {
         data = {
           index-version = "tsi1";
@@ -452,6 +451,9 @@ in
           auth-enabled = false;
           log-enabled = false;
         };
+      };
+      systemd.services.influxdb.serviceConfig = {
+        LimitNOFILE = 65535;
       };
       systemd.services.influxdb.postStart =
         let influx = "${config.services.influxdb.package}/bin/influx";

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -366,7 +366,8 @@ in
         ];
         remoteWrite = [
           { url = "http://localhost:8086/api/v1/prom/write?db=prometheus";
-            queue_config = { max_backoff = "5s"; }; }
+            queue_config = { capacity = 500000;
+                             max_backoff = "5s"; }; }
         ];
         scrapeConfigs = [
           { job_name = "prometheus";

--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -15,15 +15,9 @@ let
   cfgProxyRG = config.flyingcircus.roles.statshost-relay;
 
   promFlags = [
-    "-storage.local.retention ${toString (cfgStatsGlobal.prometheusRetention * 24)}h"
-    "-storage.local.series-file-shrink-ratio 0.3"
-    "-storage.local.target-heap-size=${toString prometheusHeap}"
-    "-storage.local.chunk-encoding-version=2"
+    "--storage.tsdb.retention ${toString (cfgStatsGlobal.prometheusRetention)}d"
   ];
   prometheusListenAddress = cfgStatsGlobal.prometheusListenAddress;
-  prometheusHeap =
-    (fclib.current_memory config 256) * 1024 * 1024
-    * cfgStatsGlobal.prometheusHeapMemoryPercentage / 100;
 
   # It's common to have stathost and loghost on the same node. Each should
   # use half of the memory then. A general approach for this kind of
@@ -176,16 +170,16 @@ in
         description = "Prometheus listen address";
       };
 
-      prometheusHeapMemoryPercentage = mkOption {
-        type = types.int;
-        default = 66 * heapCorrection / 100;
-        description = "How much RAM should go to prometheus heap.";
-      };
-
       prometheusRetention = mkOption {
         type = types.int;
         default = 70;
         description = "How long to keep data in *days*.";
+      };
+
+      influxdbRetention = mkOption {
+        type = types.str;
+        default = "inf";
+        description = "How long to keep data (influx duration)";
       };
 
       globalAllowedMetrics = mkOption {
@@ -223,22 +217,7 @@ in
     # Global stats host. Currently influxdb *and* prometheus
     (mkIf cfgStatsGlobal.enable {
 
-      # make the 'influx' command line tool accessible
-      environment.systemPackages = [ pkgs.influxdb ];
-
-      services.influxdb.enable = true;
-      services.influxdb.dataDir = "/srv/influxdb";
-      systemd.services.influxdb.serviceConfig.LimitNOFILE = "60000";
-      services.influxdb.extraConfig ={
-        data = {
-          index-version = "tsi1";
-        };
-        http = {
-          enabled = true;
-          auth-enabled = false;
-          log-enabled = false;
-        };
-
+      services.influxdb.extraConfig = {
         graphite = [
           { enabled = true;
             protocol = "udp";
@@ -304,11 +283,6 @@ in
               }];
           })
         relayLocationProxies);
-
-      # Since influx is also running on the machine, split memory between the
-      # two. Once Influx is gone, this seeting allso needs to go.
-      flyingcircus.roles.statshost.prometheusHeapMemoryPercentage = 40;
-
     })
 
     (mkIf (cfgStatsRG.enable || cfgProxyRG.enable) {
@@ -381,54 +355,129 @@ in
         # killed, a crash recovery process is started, which takes even longer.
         TimeoutStopSec = "10m";
       };
-      services.prometheus.enable = true;
-      services.prometheus.extraFlags = promFlags;
-      services.prometheus.listenAddress = prometheusListenAddress;
-      services.prometheus.scrapeConfigs = [
-        { job_name = "prometheus";
-          scrape_interval = "5s";
-          static_configs = [{
-            targets = [ prometheusListenAddress ];
-            labels = {
-              host = config.networking.hostName;
+      services.prometheus = {
+        enable = true;
+        extraFlags = promFlags;
+        listenAddress = prometheusListenAddress;
+        dataDir = "/srv/prometheus";
+        remoteRead = [
+          { url = "http://localhost:9094/api/v1/read"; }
+          { url = "http://localhost:8086/api/v1/prom/read?db=downsampled"; }
+        ];
+        remoteWrite = [
+          { url = "http://localhost:8086/api/v1/prom/write?db=prometheus";
+            queue_config = { max_backoff = "5s"; }; }
+        ];
+        scrapeConfigs = [
+          { job_name = "prometheus";
+            scrape_interval = "5s";
+            static_configs = [{
+              targets = [ prometheusListenAddress ];
+              labels = {
+                host = config.networking.hostName;
+              };
+            }];
+          }
+          rec {
+            job_name = config.flyingcircus.enc.parameters.resource_group;
+            scrape_interval = "15s";
+            # We use a file sd here. Static config would restart prometheus for
+            # each change. This way prometheus picks up the change automatically
+            # and without restart.
+            file_sd_configs = [{
+              files = [ "/etc/local/statshost/scrape-*.json" ];
+              refresh_interval = "10m";
+            }];
+            metric_relabel_configs =
+              prometheusMetricRelabel ++
+              (relabelConfiguration
+                "/etc/local/statshost/metric-relabel.${job_name}.yaml");
+          }
+          {
+            job_name = "fedrate";
+            scrape_interval = "15s";
+            metrics_path = "/federate";
+            honor_labels = true;
+            params = {
+              "match[]" = [
+                "{job=~\"static|prometheus\"}"
+              ];
             };
-          }];
-        }
-        rec {
-          job_name = config.flyingcircus.enc.parameters.resource_group;
-          scrape_interval = "15s";
-          # We use a file sd here. Static config would restart prometheus for
-          # each change. This way prometheus picks up the change automatically
-          # and without restart.
-          file_sd_configs = [{
-            files = [ "/etc/local/statshost/scrape-*.json" ];
-            refresh_interval = "10m";
-          }];
-          metric_relabel_configs =
-            prometheusMetricRelabel ++
-            (relabelConfiguration
-              "/etc/local/statshost/metric-relabel.${job_name}.yaml");
-        }
-        {
-          job_name = "fedrate";
-          scrape_interval = "15s";
-          metrics_path = "/federate";
-          honor_labels = true;
-          params = {
-            "match[]" = [
-              "{job=~\"static|prometheus\"}"
-            ];
-          };
-          file_sd_configs = [{
-            files = [ "/etc/local/statshost/federate-*.json" ];
-            refresh_interval = "10m";
-          }];
-          metric_relabel_configs = prometheusMetricRelabel;
-        }
+            file_sd_configs = [{
+              files = [ "/etc/local/statshost/federate-*.json" ];
+              refresh_interval = "10m";
+            }];
+            metric_relabel_configs = prometheusMetricRelabel;
+          }
 
-      ]
-      ++ relayRGConfig
-      ++ relayLocationConfig;
+        ]
+        ++ relayRGConfig
+        ++ relayLocationConfig;
+      };
+
+      # Read old data until expired. ~3 Month
+      systemd.services.prometheus1 = {
+        wantedBy = [ "multi-user.target" ];
+        after    = [ "network.target" ];
+        preStart = ''
+          mkdir -p /run/prometheus1
+          echo "global:" > /run/prometheus1/prometheus.yaml
+        '';
+        script = ''
+          #!/bin/sh
+          exec ${pkgs.prometheus_1}/bin/prometheus \
+            -web.listen-address "localhost:9094" \
+            -config.file /run/prometheus1/prometheus.yaml \
+            -storage.local.path=/var/lib/prometheus/metrics
+        '';
+        serviceConfig = {
+          User = "prometheus";
+          Restart  = "always";
+          WorkingDirectory = "/var/lib/prometheus";
+          PermissionsStartOnly = "true";
+        };
+      };
+
+      environment.systemPackages = [ pkgs.influxdb ];
+
+      services.influxdb.enable = true;
+      services.influxdb.dataDir = "/srv/influxdb";
+      systemd.services.influxdb.serviceConfig.LimitNOFILE = "60000";
+      services.influxdb.extraConfig = {
+        data = {
+          index-version = "tsi1";
+        };
+        http = {
+          enabled = true;
+          auth-enabled = false;
+          log-enabled = false;
+        };
+      };
+      systemd.services.influxdb.postStart =
+        let influx = "${config.services.influxdb.package}/bin/influx";
+        in ''
+          cat <<__EOF__ | ${influx}
+          CREATE DATABASE prometheus;
+
+          CREATE RETENTION POLICY "default"
+            ON prometheus
+            DURATION 1h REPLICATION 1 DEFAULT;
+
+          CREATE DATABASE downsampled;
+          CREATE RETENTION POLICY "5m"
+            ON downsampled
+            DURATION ${cfgStatsGlobal.influxdbRetention}
+            REPLICATION 1 DEFAULT;
+
+          CREATE CONTINUOUS QUERY PROM_5M
+            ON prometheus BEGIN
+              SELECT last(*) INTO downsampled."5m".:MEASUREMENT
+              FROM /.*/
+              GROUP BY TIME(5m),*
+          END;
+          __EOF__
+        '';
+
 
       system.activationScripts.statshost = {
         text = "install -d -g service -m 2775 /etc/local/statshost";

--- a/nixos/modules/flyingcircus/services/prometheus/default.nix
+++ b/nixos/modules/flyingcircus/services/prometheus/default.nix
@@ -497,6 +497,7 @@ in {
         User = promUser;
         Restart  = "always";
         WorkingDirectory = cfg.dataDir;
+        LimitNOFILE = 65535;
       };
     };
   };


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog: 

* Update Prometheus to 2.4.2. Prometheus 1.8 is kept running for about 3 months keep the metrics available (there is no data migration). (#105414).
* Statshost uses InfluxDB for long term storage with downsampled metrics (#105414).




