### PR TITLE
Make sure the default docroot of nginx is present.

### DIFF
--- a/nixos/modules/flyingcircus/roles/nginx.nix
+++ b/nixos/modules/flyingcircus/roles/nginx.nix
@@ -221,11 +221,8 @@ in
 
     system.activationScripts.nginx = ''
       install -d -o ${toString config.ids.uids.nginx} /var/log/nginx
-      install -d -o ${toString config.ids.uids.nginx} -g service -m 02775 /etc/local/nginx
-
-      # Doing this in prestart does not reliably work, because for existing
-      # nginx instances only a *reload* is triggered and no preStart.
-      install -d -o ${toString config.ids.uids.nginx} -g service -m 02775 ${docroot}
+      install -d -o ${toString config.ids.uids.nginx} -g service -m 02775 \
+        /etc/local/nginx ${docroot}
     '';
 
     services.logrotate.config = ''

--- a/nixos/modules/flyingcircus/roles/nginx.nix
+++ b/nixos/modules/flyingcircus/roles/nginx.nix
@@ -8,6 +8,8 @@ let
   then "include ${/etc/local/nginx}/*.conf;"
   else "";
 
+  docroot = "/run/nginx/docroot";
+
   baseConfig = ''
     worker_processes ${toString (fclib.current_cores config 1)};
     worker_rlimit_nofile 8192;
@@ -102,7 +104,7 @@ let
       ignore_invalid_headers on;
 
       index index.html;
-      root /var/www/localhost/htdocs;
+      root ${docroot};
 
       client_max_body_size 25m;
 
@@ -220,6 +222,10 @@ in
     system.activationScripts.nginx = ''
       install -d -o ${toString config.ids.uids.nginx} /var/log/nginx
       install -d -o ${toString config.ids.uids.nginx} -g service -m 02775 /etc/local/nginx
+
+      # Doing this in prestart does not reliably work, because for existing
+      # nginx instances only a *reload* is triggered and no preStart.
+      install -d -o ${toString config.ids.uids.nginx} -g service -m 02775 ${docroot}
     '';
 
     services.logrotate.config = ''


### PR DESCRIPTION
Logging might fail otherwise if the access_log configuration contains variables.

Bugs id# #106854

@flyingcircusio/release-managers

Impact:

Changelog:

* Make sure the default nginx docroot exists (#106854)
