### PR TITLE
Add experimental docker support.

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -66,6 +66,7 @@ in rec {
   inherit (pkgs_18_03)
     apacheHttpd
     bazaar
+    docker
     filebeat6
     nodejs-6_x
     nodejs-8_x

--- a/nixos/modules/flyingcircus/roles/default.nix
+++ b/nixos/modules/flyingcircus/roles/default.nix
@@ -19,6 +19,7 @@ in
      ./compat.nix
      ./datadog.nix
      ./dovecot.nix
+     ./docker.nix
      ./elasticsearch.nix
      ./external_net
      ./generic.nix

--- a/nixos/modules/flyingcircus/roles/docker.nix
+++ b/nixos/modules/flyingcircus/roles/docker.nix
@@ -1,0 +1,14 @@
+{ config, lib, ... }:
+{
+  options = {
+    flyingcircus.roles.docker = {
+      enable = lib.mkEnableOption "Docker";
+    };
+  };
+
+  config = lib.mkIf config.flyingcircus.roles.docker.enable {
+    virtualisation.docker.enable = true;
+    flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
+  };
+
+}

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -94,7 +94,7 @@ in
         after = [ "network.target" "docker.socket" ];
         requires = [ "docker.socket" ];
         serviceConfig = {
-          ExecStart = "${pkgs.docker}/bin/docker daemon --host=fd:// --group=docker --storage-driver=${cfg.storageDriver} ${cfg.extraOptions}";
+          ExecStart = "${pkgs.docker}/bin/dockerd --host=fd:// --group=docker --log-driver=journald --storage-driver=${cfg.storageDriver} ${cfg.extraOptions}";
           #  I'm not sure if that limits aren't too high, but it's what
           #  goes in config bundled with docker itself
           LimitNOFILE = 1048576;
@@ -120,7 +120,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         serviceConfig = {
-          ExecStart = "${pkgs.docker}/bin/docker daemon --group=docker --storage-driver=${cfg.storageDriver} ${cfg.extraOptions}";
+          ExecStart = "${pkgs.docker}/bin/dockerd --group=docker --log-driver=journald --storage-driver=${cfg.storageDriver} ${cfg.extraOptions}";
           #  I'm not sure if that limits aren't too high, but it's what
           #  goes in config bundled with docker itself
           LimitNOFILE = 1048576;

--- a/nixos/release-flyingcircus.nix
+++ b/nixos/release-flyingcircus.nix
@@ -111,6 +111,7 @@ in rec {
     tests = {
       inherit (nixos'.tests)
         firewall
+        docker
         ipv6
         misc
         nat


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:


Changelog:

* Experimental Docker support can now be enabled in NixOS VMs upon request. Service users are able to interact with the Docker daemon. Not intended for production use at the moment.