### PR TITLE
Pin HTTP service checks to v4 only.

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/monitor.py
+++ b/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/monitor.py
@@ -33,7 +33,7 @@ def get_sensucheck_configuration(servicechecks):
         path = '?'.join([p for p in [url.path, url.query] if p])
 
         command = [
-            'check_http',
+            'check_http', '-4',
             '-H', shlex.quote(url.hostname)]
         if url.port:
             command.extend(['-p', str(url.port)])


### PR DESCRIPTION
We're seeing spurious outages on v6 that appear to be a provider v6 issue in WHQ.

@flyingcircusio/release-managers

Impact:

Changelog:
