### PR TITLE
Lower swappiness even further.

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
@@ -84,7 +84,7 @@ in
   boot.supportedFilesystems = [ "xfs" ];
   boot.vesa = false;
 
-  boot.kernel.sysctl."vm.swappiness" = mkDefault 20;
+  boot.kernel.sysctl."vm.swappiness" = mkDefault 10;
 
   networking.hostName = if config.flyingcircus.enc ? name
     then config.flyingcircus.enc.name


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

Changelog:

* Further reduce swappiness to 10. 

  Our platform default is now 10 which is in line with recommendations
  "out there" (Red Hat amongst others) as a good setting to maximize
  process usage of memory (instead of swapping out) instead of caches.

  If users want caches to be used they need to tame their processes first.
  From a platform perspective we really do not want to swap out processes
  unnecessarily and rather drop VFS.