### PR TITLE
Remove idle_since tag from metrics. This creates enormous amounts of …

### DIFF
--- a/nixos/modules/flyingcircus/roles/rabbitmq.nix
+++ b/nixos/modules/flyingcircus/roles/rabbitmq.nix
@@ -145,6 +145,11 @@ in
   })
   {
     flyingcircus.roles.statshost.globalAllowedMetrics = [ "rabbitmq" ];
+    flyingcircus.roles.statshost.prometheusMetricRelabel = [
+      { regex = "idle_since";
+        action = "labeldrop"; }
+    ];
   }
+
   ];
 }


### PR DESCRIPTION
…time series which is not very prometheus friendly

Bugs id: #107461

@flyingcircusio/release-managers

Impact:

Changelog: Remove `idle_since` label from RabbitMQ metrics (#107461)
