### PR TITLE
Allow to redefine map_hash_bucket_size for Nginx Case 107386

### DIFF
--- a/nixos/modules/flyingcircus/roles/nginx/default.nix
+++ b/nixos/modules/flyingcircus/roles/nginx/default.nix
@@ -26,7 +26,7 @@ let
       default_type application/octet-stream;
       charset UTF-8;
 
-      map_hash_bucket_size 64;
+      map_hash_bucket_size ${toString cfg.roles.nginx.mapHashBucketSize};
 
       map $remote_addr $remote_addr_anon_head {
         default 0.0.0;
@@ -176,6 +176,12 @@ in
         type = types.lines;
         default = "";
         description = "Configuration lines to be appended inside of the http {} block.";
+      };
+
+      mapHashBucketSize = mkOption {
+        type = types.int;
+        default = 64;
+        description = "Bucket size for the 'map' variables hash tables.";
       };
 
     };


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:
* will restart Nginx on NixOS

Changelog:
* Allow to overwrite map_hash_bucket_size via Nix-expression

Case 107386