### PR TITLE
Always restart ElasticSearch on failure Case 107568

### DIFF
--- a/nixos/modules/flyingcircus/roles/elasticsearch.nix
+++ b/nixos/modules/flyingcircus/roles/elasticsearch.nix
@@ -144,6 +144,7 @@ in
     systemd.services.elasticsearch = {
       serviceConfig = {
         LimitMEMLOCK = "infinity";
+        Restart = "always";
       };
       preStart = mkAfter ''
         # Install scripts


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:
* Reload of unit for ElasticSearch

Changelog:
* Automatic restart ElasticSearch in case of a crash

Case 107568