### PR TITLE
don't delete datasource: grafana will update existing datasources wit…

### DIFF
--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -551,12 +551,6 @@ in
           name = "prometheus.yaml";
           text = ''
             apiVersion: 1
-
-            # list of datasources that should be deleted from the database
-            deleteDatasources:
-               - name: Prometheus
-                 orgId: 1
-
             datasources:
             - name: Prometheus
               type: prometheus


### PR DESCRIPTION
…h the same name. Deleting will re-assign ids which breaks alerting

bugs id: #107948

@flyingcircusio/release-managers

Impact:

Changelog: Fix Grafana datasource provisioning to not create new datasources on restart (#107948)
