### PR TITLE
Sensu client syntax check

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -155,6 +155,7 @@ in rec {
   fcmaintenance = pkgs.callPackage ./fcmaintenance { };
   fcmanage = pkgs.callPackage ./fcmanage { };
   fcsensuplugins = pkgs.callPackage ./fcsensuplugins { };
+  fcsensusyntax = pkgs.callPackage ./fcsensusyntax { };
   fcuserscan = pkgs.callPackage ./fcuserscan.nix { };
   fclogcheckhelper = pkgs.callPackage ./fclogcheckhelper { };
   fix-so-rpath = pkgs.callPackage ./fix-so-rpath {};

--- a/nixos/modules/flyingcircus/packages/fcsensusyntax/Cargo.lock
+++ b/nixos/modules/flyingcircus/packages/fcsensusyntax/Cargo.lock
@@ -1,0 +1,291 @@
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fc-sensu-syntax"
+version = "0.1.0"
+dependencies = [
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ryu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.15.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "534b8b91a95e0f71bca3ed5824752d558da048d4248c91af873b63bd60519752"
+"checksum serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "a915306b0f1ac5607797697148c223bedeaa36bcc2e28a01441cd638cc6567b4"
+"checksum serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "4b90a9fbe1211e57d3e1c15670f1cb00802988fb23a1a4aad7a2b63544f1920e"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/nixos/modules/flyingcircus/packages/fcsensusyntax/Cargo.toml
+++ b/nixos/modules/flyingcircus/packages/fcsensusyntax/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fc-sensu-syntax"
+version = "0.1.0"
+authors = ["Christian Kauhaus <kc@flyingcircus.io>"]
+edition = "2018"
+description = "Checks local sensu config for syntax and plausibility."
+
+[profile.release]
+panic = "abort"
+
+[dependencies]
+clap = "2.32"
+failure = "0.1.5"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"

--- a/nixos/modules/flyingcircus/packages/fcsensusyntax/default.nix
+++ b/nixos/modules/flyingcircus/packages/fcsensusyntax/default.nix
@@ -1,0 +1,18 @@
+{ pkgs, lib, stdenv, rustPlatform }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "sensu-syntax-${version}";
+  version = "0.1.0";
+
+  src = lib.cleanSource ./.;
+  cargoDepsSha256 = "1yqfyj0fa47r56gxcaqizwk7psmbxl663llah76irc4rn7cdgc74";
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Sensu client config self-check";
+    license = with licenses; [ bsd3 ];
+    platforms = platforms.all;
+  };
+}

--- a/nixos/modules/flyingcircus/packages/fcsensusyntax/src/main.rs
+++ b/nixos/modules/flyingcircus/packages/fcsensusyntax/src/main.rs
@@ -78,7 +78,7 @@ fn run<P: AsRef<Path>>(sensu_config_dir: P) -> Fallible<CheckResults> {
     Ok(read_dir(d)
         .context(format_err!("Cannot open `{}'", d.display()))?
         .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.is_file() && p.extension().unwrap_or_default() == "json")
+        .filter(|p| !p.is_dir() && p.extension().unwrap_or_default() == "json")
         .map(|p| {
             let stat = check(&p);
             (p, stat)

--- a/nixos/modules/flyingcircus/packages/fcsensusyntax/src/main.rs
+++ b/nixos/modules/flyingcircus/packages/fcsensusyntax/src/main.rs
@@ -1,0 +1,121 @@
+#[macro_use]
+extern crate clap;
+
+use clap::Arg;
+use failure::{format_err, Error, Fallible, ResultExt};
+use serde_derive::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::{read_dir, File};
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::process;
+
+#[derive(Debug, Clone, Deserialize)]
+struct ClientDef {
+    checks: HashMap<String, Value>,
+}
+
+#[derive(Debug)]
+enum Status {
+    Good(usize),  // `Ok` is already used by `Result`
+    Warning(&'static str),
+    Error(Error),
+}
+
+impl fmt::Display for Status {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Status::Good(i) => write!(f, "{} check definition(s)", i),
+            Status::Warning(msg) => write!(f, "{}", msg),
+            Status::Error(e) => {
+                let causes: Vec<_> = e.iter_chain().map(|c| c.to_string()).collect();
+                write!(f, "{}", causes.join(": "))
+            }
+        }
+    }
+}
+
+impl Status {
+    fn code(&self) -> i32 {
+        match self {
+            Status::Good(_) => 0,
+            Status::Warning(_) => 1,
+            Status::Error(_) => 2,
+        }
+    }
+
+    fn marker(&self) -> &'static str {
+        match self {
+            Status::Good(_) => "=ok=",
+            Status::Warning(_) => "warn",
+            Status::Error(_) => "crit",
+        }
+    }
+}
+
+fn decode(json: &Path) -> Fallible<ClientDef> {
+    Ok(serde_json::from_reader(BufReader::new(File::open(json)?))?)
+}
+
+fn check(sensu_client_check: &Path) -> Status {
+    let def = match decode(sensu_client_check) {
+        Ok(def) => def,
+        Err(e) => return Status::Error(e.into()),
+    };
+    if def.checks.is_empty() {
+        Status::Warning("does not contain any check definition")
+    } else {
+        Status::Good(def.checks.len())
+    }
+}
+
+type CheckResults = Vec<(PathBuf, Status)>;
+
+fn run<P: AsRef<Path>>(sensu_config_dir: P) -> Fallible<CheckResults> {
+    let d = sensu_config_dir.as_ref();
+    Ok(read_dir(d)
+        .context(format_err!("Cannot open `{}'", d.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file() && p.extension().unwrap_or_default() == "json")
+        .map(|p| {
+            let stat = check(&p);
+            (p, stat)
+        })
+        .collect())
+}
+
+fn output(mut res: CheckResults) -> i32 {
+    res.sort_by_key(|(_, s)| -s.code());
+    let max = res.iter().map(|e| e.1.code()).max().unwrap_or_default();
+    let ncrit = res.iter().filter(|e| e.1.code() >= 2).count();
+    let nwarn = res.iter().filter(|e| e.1.code() == 1).count();
+    match max {
+        0 => println!("OK: {} Sensu check config(s) found", res.len()),
+        1 => println!("WARNING: {} warning(s)", nwarn),
+        _ => println!("CRITICAL: {} error(s), {} warning(s)", ncrit, nwarn),
+    }
+    res.iter().for_each(|(f, s)| println!("[{}] {}: {}", s.marker(), f.display(), s));
+    max
+}
+
+fn main() {
+    let m = app_from_crate!()
+        .arg(
+            Arg::from_usage("[DIR] -d --directory 'Searches for local sensu checks in DIR'")
+                .default_value("/etc/local/sensu-client"),
+        )
+        .get_matches();
+    match run(m.value_of_os("DIR").unwrap()) {
+        Err(e) => {
+            print!("UNKOWN: {}", e);
+            for cause in e.iter_causes() {
+                print!(": {}", cause)
+            }
+            println!();
+            process::exit(3)
+        }
+        Ok(results) => process::exit(output(results)),
+    }
+}

--- a/nixos/modules/flyingcircus/packages/rust/default.nix
+++ b/nixos/modules/flyingcircus/packages/rust/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, callPackage }:
 
 let
-  version = "1.28.0";
+  version = "1.32.0";
 
   # fetch hashes by running `print-hashes.sh $version`
   hashes = {
-    i686-unknown-linux-gnu = "de7cdb4e665e897ea9b10bf6fd545f900683296456d6a11d8510397bb330455f";
-    x86_64-unknown-linux-gnu = "2a1390340db1d24a9498036884e6b2748e9b4b057fc5219694e298bdaa37b810";
-    armv7-unknown-linux-gnueabihf = "346558d14050853b87049e5e1fbfae0bf0360a2f7c57433c6985b1a879c349a2";
-    aarch64-unknown-linux-gnu = "9b6fbcee73070332c811c0ddff399fa31965bec62ef258656c0c90354f6231c1";
-    i686-apple-darwin = "752e2c9182e057c4a54152d1e0b3949482c225d02bb69d9d9a4127dc2a65fb68";
-    x86_64-apple-darwin = "5d7a70ed4701fe9410041c1eea025c95cad97e5b3d8acc46426f9ac4f9f02393";
+    i686-unknown-linux-gnu = "4ce3a6a656669fa86606074b43fadeac7465ef48394249407e21106ed714c8db";
+    x86_64-unknown-linux-gnu = "e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810";
+    armv7-unknown-linux-gnueabihf = "d7b69f60689d2905d8d3c2829b0f1cd0f86265a255ff88ea0deb601aebac6428";
+    aarch64-unknown-linux-gnu = "60def40961728212da4b3a9767d5a2ddb748400e150a5f8a6d5aa0e1b8ba1cee";
+    i686-apple-darwin = "76cc1280f6b61bf7cf1fddd5202cc236db7573ee05f39fc8cd12ddda8f39a7c3";
+    x86_64-apple-darwin = "f0dfba507192f9b5c330b5984ba71d57d434475f3d62bd44a39201e36fa76304";
   };
 
   platform =
@@ -33,8 +33,9 @@ let
      sha256 = hashes."${platform}";
   };
 
-in callPackage ./binaryBuild.nix
-  { inherit version src platform;
-    buildRustPackage = null;
-    versionType = "bootstrap";
-  }
+in
+callPackage ./binaryBuild.nix {
+  inherit version src platform;
+  buildRustPackage = null;
+  versionType = "bootstrap";
+}

--- a/nixos/modules/flyingcircus/packages/rust/rust-packages.nix
+++ b/nixos/modules/flyingcircus/packages/rust/rust-packages.nix
@@ -6,14 +6,14 @@
 { stdenv, fetchFromGitHub, git }:
 
 stdenv.mkDerivation rec {
-  version = "f09432f";
+  version = "e17be823e";
   name = "rustRegistry-${version}";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "crates.io-index";
     rev = version;
-    sha256 = "19lsw9y4hhi3231j5x8qcrn2fx0xifivjp010xs57yy91784gb01";
+    sha256 = "15dc1xalb7scagjnb3b4px22kzabxvajvqhr4i6xd8qz59cpi2d4";
   };
   phases = [ "unpackPhase" "installPhase" ];
   installPhase = ''

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -249,6 +249,7 @@ in {
         bash
         check-journal
         coreutils
+        fcsensusyntax
         glibc
         lm_sensors
         nagiosPluginsOfficial
@@ -306,6 +307,11 @@ in {
         notification = "Clock is skewed";
         command = "check_ntp_time -H 0.de.pool.ntp.org";
         interval = 300;
+      };
+      sensu_syntax = {
+        notification = "Problematic check definitions in /etc/local/sensu-client";
+        command = "fc-sensu-syntax";
+        interval = 60;
       };
       internet_uplink_ipv4 = uplink "4";
       internet_uplink_ipv6 = uplink "6";


### PR DESCRIPTION
This check parses all files in /etc/local/sensu-client and reports
syntax errors.

Case 108125

@flyingcircusio/release-managers

Impact:

Changelog: Monitor syntax and plausibility of user-supplied Sensu checks in `/etc/local/sensu-client` (#108125).
