### PR TITLE
Security update CUPS 2.0->2.2 (also pulling in gnpug 2.0 -> 2.2)

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -48,7 +48,9 @@ in rec {
   inherit (pkgs_18_09)
     chromedriver
     chromium
+    cups
     elasticsearch6
+    gnupg
     kibana
     mercurial
     mercurialFull


### PR DESCRIPTION
Fixes #107622

@flyingcircusio/release-managers

Impact:

Changelog:

* Security update for CUPS: 2.0.4 -> 2.2.6 (#107622)
* Update for GnuPG 2.0 -> 2.2
