### PR TITLE
Security update for graylog: 2.4.5 -> 2.4.6

### DIFF
--- a/nixos/modules/flyingcircus/packages/graylog/default.nix
+++ b/nixos/modules/flyingcircus/packages/graylog/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.5";
+  version = "2.4.6";
   name = "graylog-${version}";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "0yb8r7f64s1m83dqw64yakxmlyn7d3kdi2rd9mpw3rnz4kqcarly";
+    sha256 = "07bm5zz6b58ig082l6rwvvryh7svkv8nxp0d6izjka5f7x6g9ypw";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Fixes #108321

@flyingcircusio/release-managers

Impact:

* Graylog instances will be restarted.

Changelog:

* Security update for Graylog: 2.4.5 -> 2.4.6 (#108321)