### PR TITLE
Add PostgreSQL extension temporal_tables

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -325,6 +325,8 @@ in rec {
     inherit (pkgs_18_03) buildGoPackage fetchFromGitHub;
   };
 
+  temporal_tables = pkgs.callPackage ./postgresql/temporal_tables { };
+
   uchiwa = pkgs.callPackage ./uchiwa { };
 
   varnish =

--- a/nixos/modules/flyingcircus/packages/postgresql/temporal_tables/default.nix
+++ b/nixos/modules/flyingcircus/packages/postgresql/temporal_tables/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig, postgresql }:
+
+stdenv.mkDerivation rec {
+  name = "temporal_tables-${version}";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/arkhipov/temporal_tables/archive/v1.2.0.tar.gz";
+    sha256 = "e6d1b31a124e8597f61b86f08b6a18168f9cd9da1db77f2a8dd1970b407b7610";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D temporal_tables.so -t $out/lib/
+    install -D ./{temporal_tables-*.sql,temporal_tables.control} -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A PostgreSQL extension for temporal tables";
+    longDescription = "This extension for PostgreSQL provides support for temporal tables. System-period data versioning (also known as transaction time or system time) allows you to specify that old rows are archived into another table (that is called the history table).";
+    homepage = https://pgxn.org/dist/temporal_tables/;
+    license = licenses.postgresql;
+    maintainers = with maintainers; [ frlan ];
+  };
+}

--- a/nixos/modules/flyingcircus/roles/postgresql.nix
+++ b/nixos/modules/flyingcircus/roles/postgresql.nix
@@ -125,6 +125,7 @@ in
     services.postgresql.enable = true;
     services.postgresql.package = postgresqlPkg;
     services.postgresql.extraPlugins = [
+      (pkgs.temporal_tables.override { postgresql = postgresqlPkg; })
       (pkgs.postgis.override { postgresql = postgresqlPkg; })
     ] ++ lib.optionals
       (lib.versionAtLeast version "9.6")

--- a/nixos/modules/flyingcircus/tests/postgresql.nix
+++ b/nixos/modules/flyingcircus/tests/postgresql.nix
@@ -47,8 +47,9 @@ import ../../../tests/make-test.nix ({ rolename, lib, pkgs, ... }:
         psql --echo-all -d employees < ${selectSql} | grep -5 "John Doe"
       '';
 
-      createExtensions = pkgs.writeScript "rum-tests" ''
+      createExtensions = pkgs.writeScript "extension-tests" ''
         psql employees -c "CREATE EXTENSION rum;"
+        psql employees -c "CREATE EXTENSION temporal_tables;"
       '';
     in
     ''


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:
* Will restart PostgreSQL-servers on NixOS

Changelog:
* Add extension extension temporal_tables to default PostgreSQL-installation

Case 108908