### PR TITLE
Do not poll public NTP servers for sensu checking on each machine.

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -305,7 +305,7 @@ in {
       };
       ntp_time = {
         notification = "Clock is skewed";
-        command = "check_ntp_time -H 0.de.pool.ntp.org";
+        command = "check_ntp_time -H ${elemAt config.services.chrony.servers 0}";
         interval = 300;
       };
       sensu_syntax = {

--- a/nixos/modules/flyingcircus/static/default.nix
+++ b/nixos/modules/flyingcircus/static/default.nix
@@ -104,7 +104,7 @@ with lib;
     flyingcircus.static.ntpservers = {
       # Those are the routers and backup servers. This needs to move to the
       # directory service discovery.
-      dev = [ "barney" "eddie" "patty"];
+      dev = [ "eddie" "patty"];
       whq = [ "barbrady01" "terri" "bob" "lou" ];
       rzob = [ "kenny06" "kenny07" "barbrady02" ];
       rzrl1 = [ "kenny02" "kenny03" "barbrady03" ];


### PR DESCRIPTION
Also: fix outdated NTP server entry for DEV.

@flyingcircusio/release-managers

Impact:

Changelog:

* Use internal NTP servers for health checking to avoid false alerts when using public infrastructure. This is also much better internet citizenship. (#108793)