### PR TITLE
Add redis4 role

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -294,6 +294,8 @@ in rec {
   rabbitmq_delayed_message_exchange =
     pkgs.callPackage ./rabbitmq/delayed_message_exchange.nix { };
 
+  redis4 = pkgs.callPackage ./redis/default.nix { };
+
   rust = pkgs.callPackage ./rust/default.nix { };
   rustPlatform = pkgs.recurseIntoAttrs (makeRustPlatform rust);
   makeRustPlatform = rust: fix (self:

--- a/nixos/modules/flyingcircus/packages/redis/default.nix
+++ b/nixos/modules/flyingcircus/packages/redis/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, lua }:
+
+stdenv.mkDerivation rec {
+  version = "4.0.11";
+  name = "redis-${version}";
+
+  src = fetchurl {
+    url = "http://download.redis.io/releases/${name}.tar.gz";
+    sha256 = "1fqvxlpaxr80iykyvpf1fia8rxh4zz8paf5nnjncsssqwwxfflzw";
+  };
+
+  buildInputs = [ lua ];
+  makeFlags = "PREFIX=$(out)";
+
+  enableParallelBuilding = true;
+
+  doCheck = false; # needs tcl
+
+  meta = with stdenv.lib; {
+    homepage = https://redis.io;
+    description = "An open source, advanced key-value store";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.berdario ];
+  };
+}

--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -1,133 +1,25 @@
-{ config, lib, pkgs, ... }: with lib;
+{ config, pkgs, lib, ... }:
 
 let
-  cfg = config.flyingcircus.roles.redis;
-  fclib = import ../lib;
-
-  # This looks clunky.
-  redis_package =
-    if config.flyingcircus.roles.redis.enable
-    then pkgs.redis
-    else if config.flyingcircus.roles.redis4.enable
-    then pkgs.redis4
-    else null;
-
-  listen_addresses =
-    fclib.listenAddresses config "lo" ++
-    fclib.listenAddresses config "ethsrv";
-
-  generatedPassword =
-    lib.removeSuffix "\n" (readFile
-      (pkgs.runCommand "redis.password" {}
-      "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out"));
-
-  password = removeSuffix "\n" (
-    if cfg.password == null
-    then (fclib.configFromFile /etc/local/redis/password generatedPassword)
-    else cfg.password
-  );
-
-  extraConfig = fclib.configFromFile /etc/local/redis/custom.conf "";
+  cfg = config.flyingcircus.roles;
 
 in
+
 {
-
-  options = {
-    flyingcircus.roles.redis4 = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the Flying Circus Redis4 role.";
-      };
-
-    };
-
-    flyingcircus.roles.redis = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the Flying Circus Redis role.";
-      };
-
-      password = mkOption {
-        type = types.nullOr types.string;
-        default = null;
-        description = ''
-          The password for redis. If null, a random password will be generated.
-        '';
-      };
-
-    };
+  options.flyingcircus.roles = {
+    redis4.enable = lib.mkEnableOption "Flying Circus Redis v4";
+    redis.enable = lib.mkEnableOption "Flying Circus Redis (default version)";
   };
 
-  config = mkMerge [
-    (mkIf (redis_package != null) {
+  config = lib.mkMerge [
+    {
+      flyingcircus.services.redis.enable =
+        assert !(cfg.redis.enable && cfg.redis4.enable);
+        cfg.redis.enable || cfg.redis4.enable;
+    }
 
-    services.redis.enable = true;
-    services.redis.package = redis_package;
-    services.redis.requirePass = password;
-    services.redis.bind = concatStringsSep " " listen_addresses;
-    services.redis.extraConfig = extraConfig;
-
-    system.activationScripts.fcio-redis = ''
-      install -d -o ${toString config.ids.uids.redis} -g service -m 02775 \
-        /etc/local/redis/
-      if [[ ! -e /etc/local/redis/password ]]; then
-        ( umask 007;
-          echo ${lib.escapeShellArg password} > /etc/local/redis/password
-          chown redis:service /etc/local/redis/password
-        )
-      fi
-      chmod 0660 /etc/local/redis/password
-    '';
-
-    systemd.services.redis = rec {
-      serviceConfig = {
-        LimitNOFILE = 64000;
-        PermissionsStartOnly = true;
-      };
-
-      after = [ "network.target" "network-interfaces.target" ];
-      wants = after;
-      preStart = "echo never > /sys/kernel/mm/transparent_hugepage/enabled";
-      postStop = "echo madvise > /sys/kernel/mm/transparent_hugepage/enabled";
-    };
-
-    flyingcircus.services.sensu-client.checks = {
-      redis = {
-        notification = "Redis alive";
-        command = "check-redis-ping.rb -h localhost -P ${lib.escapeShellArg password}";
-      };
-    };
-
-    boot.kernel.sysctl = {
-      "vm.overcommit_memory" = 1;
-      "net.core.somaxconn" = 512;
-    };
-
-    services.telegraf.inputs = {
-      redis = [ {
-        servers = [
-          "tcp://:${password}@localhost:${toString config.services.redis.port}"
-        ];
-      } ];
-    };
-
-    environment.etc."local/redis/README.txt".text = ''
-      Redis ${redis_package.version} is running on this machine.
-
-      You can find the password for the redis in the `password`. You can also change
-      the redis password by changing the `password` file.
-
-      To change the redis configuration, add a file `custom.conf`, which will be
-      appended to the redis configuration.
-    '';
-  })
-
-  {
-    flyingcircus.roles.statshost.globalAllowedMetrics = [ "nginx" ];
-  }
+    (lib.mkIf cfg.redis4.enable {
+      flyingcircus.services.redis.package = pkgs.redis4;
+    })
   ];
 }

--- a/nixos/modules/flyingcircus/services/default.nix
+++ b/nixos/modules/flyingcircus/services/default.nix
@@ -13,6 +13,7 @@
      ./powerdns.nix
      ./prometheus
      ./rabbitmq.nix
+     ./redis.nix
      ./rsyslog.nix
      ./sensu/api.nix
      ./sensu/client.nix

--- a/nixos/modules/flyingcircus/services/redis.nix
+++ b/nixos/modules/flyingcircus/services/redis.nix
@@ -1,0 +1,118 @@
+{ config, lib, pkgs, ... }: with lib;
+
+let
+  cfg = config.flyingcircus.services.redis;
+  fclib = import ../lib;
+
+  listen_addresses =
+    fclib.listenAddresses config "lo" ++
+    fclib.listenAddresses config "ethsrv";
+
+  generatedPassword =
+    lib.removeSuffix "\n" (readFile
+      (pkgs.runCommand "redis.password" {}
+      "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out"));
+
+  password = removeSuffix "\n" (
+    if cfg.password == null
+    then (fclib.configFromFile /etc/local/redis/password generatedPassword)
+    else cfg.password
+  );
+
+  extraConfig = fclib.configFromFile /etc/local/redis/custom.conf "";
+
+in
+{
+
+  options = {
+    flyingcircus.services.redis = {
+
+      enable = mkEnableOption "Preconfigured Redis";
+
+      password = mkOption {
+        type = types.nullOr types.string;
+        default = null;
+        description = ''
+          The password for redis. If null, a random password will be generated.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.redis;
+        description = "The precise Redis package to use";
+        example = "pkgs.redis4";
+      };
+
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+
+      services.redis.enable = true;
+      services.redis.package = cfg.package;
+      services.redis.requirePass = password;
+      services.redis.bind = concatStringsSep " " listen_addresses;
+      services.redis.extraConfig = extraConfig;
+
+      system.activationScripts.fcio-redis = ''
+        install -d -o ${toString config.ids.uids.redis} -g service -m 02775 \
+          /etc/local/redis/
+        if [[ ! -e /etc/local/redis/password ]]; then
+          ( umask 007;
+            echo ${lib.escapeShellArg password} > /etc/local/redis/password
+            chown redis:service /etc/local/redis/password
+          )
+        fi
+        chmod 0660 /etc/local/redis/password
+      '';
+
+      systemd.services.redis = rec {
+        serviceConfig = {
+          LimitNOFILE = 64000;
+          PermissionsStartOnly = true;
+        };
+
+        after = [ "network.target" "network-interfaces.target" ];
+        wants = after;
+        preStart = "echo never > /sys/kernel/mm/transparent_hugepage/enabled";
+        postStop = "echo madvise > /sys/kernel/mm/transparent_hugepage/enabled";
+      };
+
+      flyingcircus.services.sensu-client.checks = {
+        redis = {
+          notification = "Redis alive";
+          command = "check-redis-ping.rb -h localhost -P ${lib.escapeShellArg password}";
+        };
+      };
+
+      boot.kernel.sysctl = {
+        "vm.overcommit_memory" = 1;
+        "net.core.somaxconn" = 512;
+      };
+
+      services.telegraf.inputs.redis = [
+        {
+          servers = [
+            "tcp://:${password}@localhost:${toString config.services.redis.port}"
+          ];
+        }
+      ];
+
+      environment.etc."local/redis/README.txt".text = ''
+        Redis is running on this machine.
+
+        You can find the password for the redis in the `password`. You can also change
+        the redis password by changing the `password` file.
+
+        To change the redis configuration, add a file `custom.conf`, which will be
+        appended to the redis configuration.
+      '';
+    })
+
+    {
+      flyingcircus.roles.statshost.globalAllowedMetrics = [ "redis" ];
+    }
+  ];
+}


### PR DESCRIPTION
This PR backports Redis 4.0.11 from current upstream and adds a new role redis4 

Case 108957

@flyingcircusio/release-managers

Impact:

Changelog:
* Add Redis 4.0.11