### PR TITLE
Security update for gettext.

### DIFF
--- a/pkgs/development/libraries/gettext/CVE-2018-18751.patch
+++ b/pkgs/development/libraries/gettext/CVE-2018-18751.patch
@@ -1,0 +1,132 @@
+From dce3a16e5e9368245735e29bf498dcd5e3e474a4 Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Thu, 15 Sep 2016 13:57:24 +0200
+Subject: [PATCH] xgettext: Fix crash with *.po file input
+
+When xgettext was given two *.po files with the same msgid_plural, it
+crashed with double-free.  Problem reported by Davlet Panech in:
+http://lists.gnu.org/archive/html/bug-gettext/2016-09/msg00001.html
+* gettext-tools/src/po-gram-gen.y: Don't free msgid_pluralform after
+calling do_callback_message, assuming that it takes ownership.
+* gettext-tools/src/read-catalog.c (default_add_message): Free
+msgid_plural after calling message_alloc.
+* gettext-tools/tests/xgettext-po-2: New file.
+* gettext-tools/tests/Makefile.am (TESTS): Add new test.
+---
+ gettext-tools/src/po-gram-gen.y   | 13 ++++-----
+ gettext-tools/src/read-catalog.c  |  2 ++
+ gettext-tools/tests/Makefile.am   |  2 +-
+ gettext-tools/tests/xgettext-po-2 | 55 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 63 insertions(+), 9 deletions(-)
+ create mode 100755 gettext-tools/tests/xgettext-po-2
+
+Index: gettext-0.19.7/gettext-tools/src/po-gram-gen.y
+===================================================================
+--- gettext-0.19.7.orig/gettext-tools/src/po-gram-gen.y
++++ gettext-0.19.7/gettext-tools/src/po-gram-gen.y
+@@ -221,14 +221,11 @@ message
+                   check_obsolete ($1, $3);
+                   check_obsolete ($1, $4);
+                   if (!$1.obsolete || pass_obsolete_entries)
+-                    {
+-                      do_callback_message ($1.ctxt, string2, &$1.pos, $3.string,
+-                                           $4.rhs.msgstr, $4.rhs.msgstr_len, &$4.pos,
+-                                           $1.prev_ctxt,
+-                                           $1.prev_id, $1.prev_id_plural,
+-                                           $1.obsolete);
+-                      free ($3.string);
+-                    }
++                    do_callback_message ($1.ctxt, string2, &$1.pos, $3.string,
++                                         $4.rhs.msgstr, $4.rhs.msgstr_len, &$4.pos,
++                                         $1.prev_ctxt,
++                                         $1.prev_id, $1.prev_id_plural,
++                                         $1.obsolete);
+                   else
+                     {
+                       free_message_intro ($1);
+Index: gettext-0.19.7/gettext-tools/src/read-catalog.c
+===================================================================
+--- gettext-0.19.7.orig/gettext-tools/src/read-catalog.c
++++ gettext-0.19.7/gettext-tools/src/read-catalog.c
+@@ -397,6 +397,8 @@ default_add_message (default_catalog_rea
+          appropriate.  */
+       mp = message_alloc (msgctxt, msgid, msgid_plural, msgstr, msgstr_len,
+                           msgstr_pos);
++      if (msgid_plural != NULL)
++        free (msgid_plural);
+       mp->prev_msgctxt = prev_msgctxt;
+       mp->prev_msgid = prev_msgid;
+       mp->prev_msgid_plural = prev_msgid_plural;
+Index: gettext-0.19.7/gettext-tools/tests/Makefile.am
+===================================================================
+--- gettext-0.19.7.orig/gettext-tools/tests/Makefile.am
++++ gettext-0.19.7/gettext-tools/tests/Makefile.am
+@@ -96,7 +96,7 @@ TESTS = gettext-1 gettext-2 gettext-3 ge
+ 	xgettext-perl-1 xgettext-perl-2 xgettext-perl-3 xgettext-perl-4 \
+ 	xgettext-perl-5 xgettext-perl-6 xgettext-perl-7 xgettext-perl-8 \
+ 	xgettext-php-1 xgettext-php-2 xgettext-php-3 xgettext-php-4 \
+-	xgettext-po-1 \
++	xgettext-po-1 xgettext-po-2 \
+ 	xgettext-properties-1 \
+ 	xgettext-python-1 xgettext-python-2 xgettext-python-3 \
+ 	xgettext-python-4 \
+Index: gettext-0.19.7/gettext-tools/tests/xgettext-po-2
+===================================================================
+--- /dev/null
++++ gettext-0.19.7/gettext-tools/tests/xgettext-po-2
+@@ -0,0 +1,55 @@
++#! /bin/sh
++. "${srcdir=.}/init.sh"; path_prepend_ . ../src
++
++# Test PO extractors with multiple input files.
++
++cat <<EOF > xg-po-2-1.po
++msgid "first msgid"
++msgid_plural "first msgid (plural)"
++msgstr[0] ""
++msgstr[1] ""
++
++msgid "second msgid"
++msgid_plural "second msgid (plural)"
++msgstr[0] ""
++msgstr[1] ""
++EOF
++
++cat <<EOF > xg-po-2-2.po
++msgid "third msgid"
++msgid_plural "third msgid (plural)"
++msgstr[0] ""
++msgstr[1] ""
++
++msgid "second msgid"
++msgid_plural "second msgid (plural)"
++msgstr[0] ""
++msgstr[1] ""
++EOF
++
++: ${XGETTEXT=xgettext}
++${XGETTEXT} --omit-header xg-po-2-1.po xg-po-2-2.po -o xg-po-2.tmp.po || Exit 1
++LC_ALL=C tr -d '\r' < xg-po-2.tmp.po > xg-po-2.po || Exit 1
++
++cat <<EOF > xg-po-2.ok
++msgid "first msgid"
++msgid_plural "first msgid (plural)"
++msgstr[0] ""
++msgstr[1] ""
++
++msgid "second msgid"
++msgid_plural "second msgid (plural)"
++msgstr[0] ""
++msgstr[1] ""
++
++msgid "third msgid"
++msgid_plural "third msgid (plural)"
++msgstr[0] ""
++msgstr[1] ""
++EOF
++
++: ${DIFF=diff}
++${DIFF} xg-po-2.ok xg-po-2.po
++result=$?
++
++exit $result

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libiconv, xz }:
+{ stdenv, fetchurl, libiconv, xz, bison, automake115x, autoconf }:
 
 stdenv.mkDerivation (rec {
   name = "gettext-0.19.5.1";
@@ -7,6 +7,8 @@ stdenv.mkDerivation (rec {
     url = "mirror://gnu/gettext/${name}.tar.gz";
     sha256 = "0cbp498ckjwj7qr8b9pmkry8hkhldgkvg5yix8hi9c8z1hxxb651";
   };
+
+  patches = [ ./CVE-2018-18751.patch ];
 
   outputs = [ "out" "doc" ];
 
@@ -41,7 +43,7 @@ stdenv.mkDerivation (rec {
     sed -i -e "s/\(am_libgettextlib_la_OBJECTS = \)error.lo/\\1/" gettext-tools/gnulib-lib/Makefile.in
   '';
 
-  buildInputs = [ xz ] ++ stdenv.lib.optional (!stdenv.isLinux) libiconv;
+  buildInputs = [ xz bison automake115x autoconf ] ++ stdenv.lib.optional (!stdenv.isLinux) libiconv;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Impact:

* Many services will be restarted due to the widespread dependency on gettext.

Changelog:

* Security update for gettext (#107624)
