### PR TITLE
avoid running fc-collect-garbage shortly after timer has been rebuilt

### DIFF
--- a/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
+++ b/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
@@ -113,7 +113,7 @@ in {
         description = "Timer for fc-collect-garbage";
         wantedBy = [ "timers.target" ];
         timerConfig = {
-          OnStartupSec = "49m";
+          OnActiveSec = "2h 30m";
           OnUnitInactiveSec = "1d";
           AccuracySec = "1h";
         };


### PR DESCRIPTION
Using OnActiveSec=2h 30m runs the timer 2 hours and 30 minutes after its activation.
The old setting caused the timer to run 49 minutes after systemd was
started which can trigger the timer shortly after a rebuild. We want to
run it later to avoid high io load.

@flyingcircusio/release-managers

Impact:

Changelog:

* don't run garbage collection shortly after timer rebuild; increase initial waiting time to 2 hours and 30 minutes