### PR TITLE
start important network services after network-interfaces

### DIFF
--- a/nixos/modules/flyingcircus/roles/apache.nix
+++ b/nixos/modules/flyingcircus/roles/apache.nix
@@ -55,10 +55,13 @@ in
       ${localConfig}
     '';
 
-    systemd.services.httpd.preStart = ''
-      install -d -o ${config.services.httpd.user} -g service -m 02775 /etc/local/apache
-      install -d -o root -g service -m 02755 ${config.services.httpd.logDir}
-    '';
+    systemd.services.httpd = {
+      after = [ "network-interfaces.target" ];
+      preStart = ''
+        install -d -o ${config.services.httpd.user} -g service -m 02775 /etc/local/apache
+        install -d -o root -g service -m 02755 ${config.services.httpd.logDir}
+      '';
+    };
 
     services.logrotate.config = ''
         /var/log/httpd/*access*log

--- a/nixos/modules/flyingcircus/roles/haproxy.nix
+++ b/nixos/modules/flyingcircus/roles/haproxy.nix
@@ -85,6 +85,7 @@ in
       haproxy_ = "${pkgs.haproxy}/bin/haproxy -f /etc/current-config/haproxy.cfg -p /run/haproxy.pid -Ws";
       verifyConfig = "${pkgs.haproxy}/bin/haproxy -c -q -f /etc/current-config/haproxy.cfg";
       in {
+      after = [ "network-interfaces.target" ];
       reloadIfChanged = true;
       restartTriggers = [ haproxyCfg ];
       reload = ''
@@ -132,7 +133,7 @@ in
     systemd.services.prometheus-haproxy-exporter = {
       description = "Prometheus exporter for haproxy metrics";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      after = [ "haproxy.service" ];
       path = [ pkgs.haproxy ];
       script = ''
         exec ${pkgs.prometheus-haproxy-exporter}/bin/haproxy_exporter \

--- a/nixos/modules/flyingcircus/roles/nginx/default.nix
+++ b/nixos/modules/flyingcircus/roles/nginx/default.nix
@@ -220,6 +220,10 @@ in
     services.nginx.config = "";
     services.nginx.appendConfig = baseConfig;
 
+    systemd.services.nginx = {
+      after = [ "network-interfaces.target" ];
+    };
+
     # XXX only on FE!
     networking.firewall.allowedTCPPorts = [ 80 443 ];
 

--- a/nixos/modules/flyingcircus/roles/webproxy.nix
+++ b/nixos/modules/flyingcircus/roles/webproxy.nix
@@ -55,7 +55,7 @@ in
     services.varnish.stateDir = "/var/spool/varnish/${config.networking.hostName}";
     systemd.services.varnish = {
       # XXX: needs to be migrated to upstream varnish service
-      after = [ "network.target" ];
+      after = [ "network.target" "network-interfaces.target" ];
       path = [ pkgs.varnish pkgs.procps pkgs.gawk ];
       preStart = lib.mkAfter ''
         install -d -o ${toString config.ids.uids.varnish} -g service -m 02775 /etc/local/varnish

--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -245,7 +245,7 @@ in {
 
     systemd.services.sensu-client = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      after = [ "network.target" "network-interfaces.target" ];
       stopIfChanged = false;
 
       path = [


### PR DESCRIPTION


* affects service units that had an after dependency on network.target,
but not network-interfaces.target
* prometheus-node-exporter depends on haproxy now instead of network.target

@flyingcircusio/release-managers

Impact:

Changelog:

* Avoid service startup errors by starting varnish, haproxy, nginx and httpd after network interfaces