### PR TITLE
Fix atomic updates of statshost relay configs to stop prometheus from…

### DIFF
--- a/nixos/modules/flyingcircus/roles/statshost/default.nix
+++ b/nixos/modules/flyingcircus/roles/statshost/default.nix
@@ -330,8 +330,9 @@ in
         path = [ pkgs.curl pkgs.coreutils ];
         script = concatStringsSep "\n" (map
           (relayNode: ''
-            curl -s -o /var/cache/statshost-relay-${relayNode.job_name}.json \
-              ${relayNode.proxy_url}/scrapeconfig.json
+            curl -s -o /var/cache/.statshost-relay-${relayNode.job_name}.json.download \
+              ${relayNode.proxy_url}/scrapeconfig.json && \
+              mv /var/cache/.statshost-relay-${relayNode.job_name}.json.download /var/cache/statshost-relay-${relayNode.job_name}.json
           '')
           relayRGNodes);
       });


### PR DESCRIPTION
… complaining.

@flyingcircusio/release-managers

Impact:

Changelog:

* Fix atomic updates of statshost relay configs to stop prometheus from complaining when curl rewrites the file on the fly. (#100108)