### PR TITLE
Fix external_net role, when no reverse DNS entry is set

### DIFF
--- a/nixos/modules/flyingcircus/roles/external_net/default.nix
+++ b/nixos/modules/flyingcircus/roles/external_net/default.nix
@@ -18,6 +18,7 @@ let
 
   # pick a suitable DNS name for client config
   domain = config.networking.domain;
+  location = lib.attrByPath [ "parameters" "location" ] "standalone" cfg.enc;
   defaultFrontendName =
     if feReverses != {}
     then fclib.normalizeDomain domain (head (attrValues feReverses))


### PR DESCRIPTION
bugs id: #100057

@flyingcircusio/release-managers

Impact:

Changelog: Fix enabling external_net role, when no reverse DNS entry is set (#100057)