### PR TITLE
disable policy routing for WDS

### DIFF
--- a/nixos/modules/flyingcircus/roles/webdata_blackbee.nix
+++ b/nixos/modules/flyingcircus/roles/webdata_blackbee.nix
@@ -136,5 +136,8 @@ in
         routes}
     '';
 
+    # Policy routing doesn't work with the routing via VPN. But everything
+    # works without policy routing. So disable it.
+    flyingcircus.network.policyRouting.enable = lib.mkForce false;
   };
 }


### PR DESCRIPTION
This doesn't interact well with the VPN setup and matches disabling when external_net is available.

bugs id: #110577

@flyingcircusio/release-managers

Impact:

Changelog: Update network settings in customer-specific situation (#110577)
