### PR TITLE
Update production VMs in maintenance.

### DIFF
--- a/nixos/modules/flyingcircus/roles/webdata_blackbee.nix
+++ b/nixos/modules/flyingcircus/roles/webdata_blackbee.nix
@@ -135,7 +135,5 @@ in
     # works without policy routing. So disable it.
     flyingcircus.network.policyRouting.enable = lib.mkForce false;
 
-    # Production VMs are being updated with maintenance
-    flyingcircus.agent.with-maintenance = config.flyingcircus.enc.parameters.production;
   };
 }

--- a/nixos/modules/flyingcircus/services/agent.nix
+++ b/nixos/modules/flyingcircus/services/agent.nix
@@ -27,8 +27,8 @@ in {
       };
 
       with-maintenance = mkOption {
-        default = false;
-        description = "Perform channel updates in scheduled maintenance.";
+        default = config.flyingcircus.enc.parameters.production;
+        description = "Perform channel updates in scheduled maintenance. Default: all production VMs";
         type = types.bool;
       };
 

--- a/nixos/modules/flyingcircus/tests/default.nix
+++ b/nixos/modules/flyingcircus/tests/default.nix
@@ -11,6 +11,7 @@
   inherit (import ./elasticsearch.nix { inherit system hydraJob; })
     elasticsearch5 elasticsearch6;
 
+  fcmanage = hydraJob (import ./fcmanage.nix { inherit system; });
   firewall = hydraJob (import ./firewall/atomic.nix { inherit system; });
 
   graylog = hydraJob (import ./graylog.nix { inherit system; });

--- a/nixos/modules/flyingcircus/tests/fcmanage.nix
+++ b/nixos/modules/flyingcircus/tests/fcmanage.nix
@@ -1,0 +1,52 @@
+import ../../../tests/make-test.nix ({ pkgs, ... }:
+let
+  agent_updates_channel_with_maintenance = pkgs.writeScript "agent-updates-channel-with-maintenance" ''
+      #!/bin/sh
+      set -x
+      x=$(grep ExecStart /etc/systemd/system/fc-manage.service)
+      x=''${x/ExecStart=/}
+      cat $x
+      grep 'channel-with-maintenance' $x
+      '';
+in
+  {
+  name = "fc-manage";
+  nodes = {
+    prod =
+      { config, lib, ... }:
+      {
+        imports = [
+          ./setup.nix
+          ../platform
+          ../roles
+          ../services
+          ../static
+        ];
+        config.flyingcircus.agent.enable = lib.mkForce true;
+        config.flyingcircus.enc.parameters.production = true;
+      };
+
+    nonprod =
+      { config, lib, ... }:
+      {
+        imports = [
+          ./setup.nix
+          ../platform
+          ../roles
+          ../services
+          ../static
+        ];
+        config.flyingcircus.agent.enable = lib.mkForce true;
+        config.flyingcircus.enc.parameters.production = false;
+      };
+
+  };
+  testScript = ''
+    $nonprod->waitForUnit('multi-user.target');
+    $nonprod->fail('${agent_updates_channel_with_maintenance}');
+
+    $prod->waitForUnit('multi-user.target');
+    $prod->succeed('${agent_updates_channel_with_maintenance}');
+  '';
+})
+


### PR DESCRIPTION
This will reduce unexpected downtimes where our prediction model is missing
critical things that should go without downtime but then causes downtime.

Fixes #110759

@flyingcircusio/release-managers

Impact:

- No immediate impact. Future updates will cause more maintenance notifications, though.

Changelog:

- Always update production VMs in maintenance windows (in the future). New configs will continue to be built immediately but activation will be scheduled as a maintenance.