### PR TITLE
Ensure that a sudo password is needed for the wheel group

### DIFF
--- a/nixos/modules/flyingcircus/platform/user.nix
+++ b/nixos/modules/flyingcircus/platform/user.nix
@@ -140,6 +140,10 @@ in
       Defaults set_home,!authenticate,!mail_no_user
       Defaults lecture = never
 
+      # This ensures that a password is needed for users in the wheel group.
+      # Overrides NixOS rule above.
+      %wheel ALL=(ALL) PASSWD: ALL
+
       # Allow unrestricted access to super admins
       %admins ALL=(ALL) PASSWD: ALL
 


### PR DESCRIPTION
Case 114332

@flyingcircusio/release-managers

Impact:

Changelog:

* Ensure that a sudo password is always needed for the wheel group (#114332).