### PR TITLE
Allow sensuclient to sudo run as a service user

### DIFF
--- a/nixos/modules/flyingcircus/services/sensu/client.nix
+++ b/nixos/modules/flyingcircus/services/sensu/client.nix
@@ -257,6 +257,7 @@ in {
 
        %sensuclient ALL=(root) MULTIPING
        %sensuclient ALL=(root) CHECK_DISK
+       %sensuclient ALL=(%service) ALL
    '';
 
     systemd.services.sensu-client = {


### PR DESCRIPTION
Case 115283

Changelog

* Allow sensu checks to switch to a service user without password (#115283).