### PR TITLE
Fix case 117071 and case 114925: always restart redis and mysql on un…

### DIFF
--- a/nixos/modules/flyingcircus/roles/mysql.nix
+++ b/nixos/modules/flyingcircus/roles/mysql.nix
@@ -279,6 +279,12 @@ in
       https://flyingcircus.io/doc/guide/platform_nixos/mysql.html.
     '';
 
+    systemd.services.mysql = {
+      serviceConfig = {
+          Restart = "always";
+        };
+    };
+
     systemd.services.mysql-maintenance = {
       description = "Timed MySQL maintenance tasks";
       after = [ "mysql.service" ];

--- a/nixos/modules/flyingcircus/services/redis.nix
+++ b/nixos/modules/flyingcircus/services/redis.nix
@@ -72,6 +72,7 @@ in
         serviceConfig = {
           LimitNOFILE = 64000;
           PermissionsStartOnly = true;
+          Restart = "always";
         };
 
         after = [ "network.target" "network-interfaces.target" ];


### PR DESCRIPTION
…expected exits.

@flyingcircusio/release-managers

## Release process

Impact:

- MySQL will be restarted.
- Redis will be restarted.

Changelog:

- Fix automatic restart for MySQL (#117071).
- Fix automatic restart for Redis (#114925).

## Security implications

Not applicable for this change.

- [x] [Security requirements] (https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

