### PR TITLE
Nginx: fix reload/LE problems with vhosts configured via JSON config

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -32,14 +32,14 @@ rec {
 
     import ./eval-config.nix {
       inherit system;
-      modules = configurations ++
+      modules = configurations ++ extraConfigurations;
+      baseModules =  (import ../modules/module-list.nix) ++
         [ ../modules/virtualisation/qemu-vm.nix
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
           { key = "no-manual"; documentation.nixos.enable = false; }
           { key = "qemu"; system.build.qemu = qemu; }
-        ] ++ optional minimal ../modules/testing/minimal-kernel.nix
-          ++ extraConfigurations;
-      extraArgs = { inherit nodes; };
+          { key = "nodes"; _module.args.nodes = nodes; }
+        ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
     };
 
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -284,6 +284,11 @@ with lib;
 
     (mkRenamedOptionModule [ "programs" "zsh" "enableAutosuggestions" ] [ "programs" "zsh" "autosuggestions" "enable" ])
 
+    # ACME
+     (mkRemovedOptionModule [ "security" "acme" "directory"] "ACME Directory is now hardcoded to /var/lib/acme and its permisisons are managed by systemd. See https://github.com/NixOS/nixpkgs/issues/53852 for more info.")
+     (mkRemovedOptionModule [ "security" "acme" "preDelay"] "This option has been removed. If you want to make sure that something executes before certificates are provisioned, add a RequiredBy=acme-\${cert}.service to the service you want to execute before the cert renewal")
+     (mkRemovedOptionModule [ "security" "acme" "activationDelay"] "This option has been removed. If you want to make sure that something executes before certificates are provisioned, add a RequiredBy=acme-\${cert}.service to the service you want to execute before the cert renewal")
+
     # Xen
     (mkRenamedOptionModule [ "virtualisation" "xen" "qemu-package" ] [ "virtualisation" "xen" "package-qemu" ])
 

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -69,9 +69,9 @@ let
       plugins = mkOption {
         type = types.listOf (types.enum [
           "cert.der" "cert.pem" "chain.pem" "external.sh"
-          "fullchain.pem" "full.pem" "key.der" "key.pem" "account_key.json"
+          "fullchain.pem" "full.pem" "key.der" "key.pem" "account_key.json" "account_reg.json"
         ]);
-        default = [ "fullchain.pem" "full.pem" "key.pem" "account_key.json" ];
+        default = [ "fullchain.pem" "full.pem" "key.pem" "account_key.json" "account_reg.json" ];
         description = ''
           Plugins to enable. With default settings simp_le will
           store public certificate bundle in <filename>fullchain.pem</filename>,
@@ -198,7 +198,7 @@ in
                           ++ optionals (data.email != null) [ "--email" data.email ]
                           ++ concatMap (p: [ "-f" p ]) data.plugins
                           ++ concatLists (mapAttrsToList (name: root: [ "-d" (if root == null then name else "${name}:${root}")]) data.extraDomains)
-                          ++ optionals (!cfg.production) ["--server" "https://acme-staging.api.letsencrypt.org/directory"];
+                          ++ optionals (!cfg.production) ["--server" "https://acme-staging-v02.api.letsencrypt.org/directory"];
                 acmeService = {
                   description = "Renew ACME Certificate for ${cert}";
                   after = [ "network.target" "network-online.target" ];

--- a/nixos/modules/security/acme.xml
+++ b/nixos/modules/security/acme.xml
@@ -59,10 +59,8 @@ http {
   <para>
    The private key <filename>key.pem</filename> and certificate
    <filename>fullchain.pem</filename> will be put into
-   <filename>/var/lib/acme/foo.example.com</filename>. The target directory can
-   be configured with the option <xref linkend="opt-security.acme.directory"/>.
+   <filename>/var/lib/acme/foo.example.com</filename>.
   </para>
-
   <para>
    Refer to <xref linkend="ch-options" /> for all available configuration
    options for the <link linkend="opt-security.acme.certs">security.acme</link>

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -4,23 +4,25 @@ with lib;
 
 let
   cfg = config.services.nginx;
+  certs = config.security.acme.certs;
+  vhostsConfigs = mapAttrsToList (vhostName: vhostConfig: vhostConfig) virtualHosts;
+  acmeEnabledVhosts = filter (vhostConfig: vhostConfig.enableACME && vhostConfig.useACMEHost == null) vhostsConfigs;
   virtualHosts = mapAttrs (vhostName: vhostConfig:
     let
       serverName = if vhostConfig.serverName != null
         then vhostConfig.serverName
         else vhostName;
-      acmeDirectory = config.security.acme.directory;
     in
     vhostConfig // {
       inherit serverName;
     } // (optionalAttrs vhostConfig.enableACME {
-      sslCertificate = "${acmeDirectory}/${serverName}/fullchain.pem";
-      sslCertificateKey = "${acmeDirectory}/${serverName}/key.pem";
-      sslTrustedCertificate = "${acmeDirectory}/${serverName}/full.pem";
+      sslCertificate = "${certs.${serverName}.directory}/fullchain.pem";
+      sslCertificateKey = "${certs.${serverName}.directory}/key.pem";
+      sslTrustedCertificate = "${certs.${serverName}.directory}/full.pem";
     }) // (optionalAttrs (vhostConfig.useACMEHost != null) {
-      sslCertificate = "${acmeDirectory}/${vhostConfig.useACMEHost}/fullchain.pem";
-      sslCertificateKey = "${acmeDirectory}/${vhostConfig.useACMEHost}/key.pem";
-      sslTrustedCertificate = "${acmeDirectory}/${vhostConfig.useACMEHost}/full.pem";
+      sslCertificate = "${certs.${vhostConfig.useACMEHost}.directory}/fullchain.pem";
+      sslCertificateKey = "${certs.${vhostConfig.useACMEHost}.directory}/key.pem";
+      sslTrustedCertificate = "${certs.${vhostConfig.useACMEHost}.directory}/fullchain.pem";
     })
   ) cfg.virtualHosts;
   enableIPv6 = config.networking.enableIPv6;
@@ -647,8 +649,10 @@ in
 
     systemd.services.nginx = {
       description = "Nginx Web Server";
-      after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+      wants = concatLists (map (vhostConfig: ["acme-${vhostConfig.serverName}.service" "acme-selfsigned-${vhostConfig.serverName}.service"]) acmeEnabledVhosts);
+      after = [ "network.target" ] ++ map (vhostConfig: "acme-selfsigned-${vhostConfig.serverName}.service") acmeEnabledVhosts;
+      stopIfChanged = false;
       preStart =
         ''
         ${cfg.preStart}
@@ -712,8 +716,6 @@ in
 
     security.acme.certs = filterAttrs (n: v: v != {}) (
       let
-        vhostsConfigs = mapAttrsToList (vhostName: vhostConfig: vhostConfig) virtualHosts;
-        acmeEnabledVhosts = filter (vhostConfig: vhostConfig.enableACME && vhostConfig.useACMEHost == null) vhostsConfigs;
         acmePairs = map (vhostConfig: { name = vhostConfig.serverName; value = {
             user = cfg.user;
             group = lib.mkDefault cfg.group;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -184,11 +184,11 @@ let
         defaultListen =
           if vhost.listen != [] then vhost.listen
           else ((optionals hasSSL (
-            singleton                    { addr = "0.0.0.0"; port = 443; ssl = true; }
-            ++ optional enableIPv6 { addr = "[::]";    port = 443; ssl = true; }
+            singleton                    { addr = vhost.listenAddress; port = 443; ssl = true; }
+            ++ optional enableIPv6 { addr = vhost.listenAddress6;    port = 443; ssl = true; }
           )) ++ optionals (!onlySSL) (
-            singleton                    { addr = "0.0.0.0"; port = 80;  ssl = false; }
-            ++ optional enableIPv6 { addr = "[::]";    port = 80;  ssl = false; }
+            singleton                    { addr = vhost.listenAddress; port = 80;  ssl = false; }
+            ++ optional enableIPv6 { addr = vhost.listenAddress6;    port = 80;  ssl = false; }
           ));
 
         hostListen =

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -652,6 +652,7 @@ in
       wantedBy = [ "multi-user.target" ];
       wants = concatLists (map (vhostConfig: ["acme-${vhostConfig.serverName}.service" "acme-selfsigned-${vhostConfig.serverName}.service"]) acmeEnabledVhosts);
       after = [ "network.target" ] ++ map (vhostConfig: "acme-selfsigned-${vhostConfig.serverName}.service") acmeEnabledVhosts;
+      before = map (vhostConfig: "acme-${vhostConfig.serverName}.service") acmeEnabledVhosts;
       stopIfChanged = false;
       preStart =
         ''
@@ -685,7 +686,7 @@ in
           ${pkgs.coreutils}/bin/kill -QUIT $MAINPID
         else
           # We only need to change the configuration, so update it and reload nginx
-          echo "Restart not needed, reload now"
+          echo "Reloading Nginx now"
           ln -sf ${configFile} /run/nginx/config
           ${pkgs.coreutils}/bin/kill -HUP $MAINPID
         fi

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -46,6 +46,24 @@ with lib;
       '';
     };
 
+    listenAddress = mkOption { 
+      type = types.str;
+      description = ''
+        IPv4 address to listen to. Defaults to 0.0.0.0.
+        If you need more options, use <option>listen</option>.
+      '';
+      default = "0.0.0.0";
+    };
+
+    listenAddress6 = mkOption { 
+      type = types.str;
+      description = ''
+        IPv6 address to listen to. Defaults to [::].
+        If you need more options, use <option>listen</option>.
+      '';
+      default = "[::]";
+    };
+
     enableACME = mkOption {
       type = types.bool;
       default = false;

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -434,6 +434,8 @@ system("@systemd@/bin/systemd-tmpfiles", "--create", "--remove", "--exclude-pref
 # units.
 if (scalar(keys %unitsToReload) > 0) {
     print STDERR "reloading the following units: ", join(", ", sort(keys %unitsToReload)), "\n";
+    # FCIO: also starts dependencies of units that will be reloaded
+    system("@systemd@/bin/systemctl", "start", "--", sort(keys %unitsToReload)) == 0 or $res = 4;
     system("@systemd@/bin/systemctl", "reload", "--", sort(keys %unitsToReload)) == 0 or $res = 4;
     unlink($reloadListFile);
 }

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -3,19 +3,49 @@ let
 in import ./make-test.nix {
   name = "acme";
 
-  nodes = {
+  nodes = rec {
     letsencrypt = ./common/letsencrypt;
+
+    acmeStandalone = { config, pkgs, ... }: {
+      imports = [ commonConfig ];
+      networking.firewall.allowedTCPPorts = [ 80 ];
+      networking.extraHosts = ''
+        ${config.networking.primaryIPAddress} standalone.com
+      '';
+      security.acme.certs."standalone.com" = {
+        webroot = "/var/lib/acme/acme-challenges";
+      };
+      systemd.targets."acme-finished-standalone.com" = {};
+      systemd.services."acme-standalone.com" = {
+        wants = [ "acme-finished-standalone.com.target" ];
+        before = [ "acme-finished-standalone.com.target" ];
+      };
+      services.nginx.enable = true;
+      services.nginx.virtualHosts."standalone.com" = {
+        locations."/.well-known/acme-challenge".root = "/var/lib/acme/acme-challenges";
+      };
+    };
 
     webserver = { config, pkgs, ... }: {
       imports = [ commonConfig ];
       networking.firewall.allowedTCPPorts = [ 80 443 ];
 
       networking.extraHosts = ''
-        ${config.networking.primaryIPAddress} example.com
+        ${config.networking.primaryIPAddress} a.example.com
+        ${config.networking.primaryIPAddress} b.example.com
       '';
 
+      # A target remains active. Use this to probe the fact that
+      # a service fired eventhough it is not RemainAfterExit
+      systemd.targets."acme-finished-a.example.com" = {};
+      systemd.services."acme-a.example.com" = {
+        wants = [ "acme-finished-a.example.com.target" ];
+        before = [ "acme-finished-a.example.com.target" ];
+      };
+
       services.nginx.enable = true;
-      services.nginx.virtualHosts."example.com" = {
+
+      services.nginx.virtualHosts."a.example.com" = {
         enableACME = true;
         forceSSL = true;
         locations."/".root = pkgs.runCommand "docroot" {} ''
@@ -23,17 +53,63 @@ in import ./make-test.nix {
           echo hello world > "$out/index.html"
         '';
       };
+
+      nesting.clone = [
+        ({pkgs, ...}: {
+
+          networking.extraHosts = ''
+            ${config.networking.primaryIPAddress} b.example.com
+          '';
+          systemd.targets."acme-finished-b.example.com" = {};
+          systemd.services."acme-b.example.com" = {
+            wants = [ "acme-finished-b.example.com.target" ];
+            before = [ "acme-finished-b.example.com.target" ];
+          };
+          services.nginx.virtualHosts."b.example.com" = {
+            enableACME = true;
+            forceSSL = true;
+            locations."/".root = pkgs.runCommand "docroot" {} ''
+              mkdir -p "$out"
+              echo hello world > "$out/index.html"
+            '';
+          };
+        })
+      ];
     };
 
     client = commonConfig;
   };
 
-  testScript = ''
-    $letsencrypt->waitForUnit("default.target");
-    $letsencrypt->waitForUnit("boulder.service");
-    $webserver->waitForUnit("default.target");
-    $webserver->waitForUnit("acme-certificates.target");
-    $client->waitForUnit("default.target");
-    $client->succeed('curl https://example.com/ | grep -qF "hello world"');
-  '';
+  testScript = {nodes, ...}: 
+    let
+      newServerSystem = nodes.webserver2.config.system.build.toplevel;
+      switchToNewServer = "${newServerSystem}/bin/switch-to-configuration test";
+    in
+    # Note, waitForUnit does not work for oneshot services that do not have RemainAfterExit=true,
+    # this is because a oneshot goes from inactive => activating => inactive, and never
+    # reaches the active state. To work around this, we create some mock target units which
+    # get pulled in by the oneshot units. The target units linger after activation, and hence we
+    # can use them to probe that a oneshot fired. It is a bit ugly, but it is the best we can do
+    ''
+      $client->waitForUnit("default.target");
+      $letsencrypt->waitForUnit("default.target");
+      $letsencrypt->waitForUnit("boulder.service");
+
+      subtest "can request certificate with HTTPS-01 challenge", sub {
+        $acmeStandalone->waitForUnit("default.target");
+        $acmeStandalone->succeed("systemctl start acme-standalone.com.service");
+        $acmeStandalone->waitForUnit("acme-finished-standalone.com.target");
+      };
+
+      subtest "Can request certificate for nginx service", sub {
+        $webserver->waitForUnit("acme-finished-a.example.com.target");
+        $client->succeed('curl https://a.example.com/ | grep -qF "hello world"');
+      };
+
+      subtest "Can add another certificate for nginx service", sub {
+        $webserver->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
+        $webserver->waitForUnit("acme-finished-b.example.com.target");
+        $client->succeed('curl https://b.example.com/ | grep -qF "hello world"');
+      };
+    '';
 }

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -1,115 +1,101 @@
 let
-  commonConfig = ./common/letsencrypt/common.nix;
-in import ./make-test.nix {
+  domainA = "a.example.com";
+  domainB = "b.example.com";
+in
+import ./make-test.nix ({ pkgs, lib, ... }: {
   name = "acme";
 
-  nodes = rec {
-    letsencrypt = ./common/letsencrypt;
+  nodes =
+  let
+    fakeAcme = domain: {
+      # A target remains active. Use this to probe the fact that
+      # a service fired even though it is not RemainAfterExit
 
-    acmeStandalone = { config, pkgs, ... }: {
-      imports = [ commonConfig ];
-      networking.firewall.allowedTCPPorts = [ 80 ];
-      networking.extraHosts = ''
-        ${config.networking.primaryIPAddress} standalone.com
-      '';
-      security.acme.certs."standalone.com" = {
-        webroot = "/var/lib/acme/acme-challenges";
-      };
-      systemd.targets."acme-finished-standalone.com" = {};
-      systemd.services."acme-standalone.com" = {
-        wants = [ "acme-finished-standalone.com.target" ];
-        before = [ "acme-finished-standalone.com.target" ];
-      };
-      services.nginx.enable = true;
-      services.nginx.virtualHosts."standalone.com" = {
-        locations."/.well-known/acme-challenge".root = "/var/lib/acme/acme-challenges";
+      systemd.targets."acme-finished-${domain}" = {};
+
+      systemd.services."acme-${domain}" = {
+        wants = [ "acme-finished-${domain}.target" ];
+        before = [ "acme-finished-${domain}.target" ];
+        serviceConfig.ExecStart = lib.mkForce (pkgs.writeScript "fake-acme" ''
+          #!${pkgs.runtimeShell}
+          set -x
+          echo "starting fake cert fetch for ${domain}..."
+          
+          sleep 3
+          echo "fetched cert for ${domain}"
+        '');
       };
     };
 
-    webserver = { config, pkgs, ... }: {
-      imports = [ commonConfig ];
-      networking.firewall.allowedTCPPorts = [ 80 443 ];
-
-      networking.extraHosts = ''
-        ${config.networking.primaryIPAddress} a.example.com
-        ${config.networking.primaryIPAddress} b.example.com
-      '';
-
-      # A target remains active. Use this to probe the fact that
-      # a service fired eventhough it is not RemainAfterExit
-      systemd.targets."acme-finished-a.example.com" = {};
-      systemd.services."acme-a.example.com" = {
-        wants = [ "acme-finished-a.example.com.target" ];
-        before = [ "acme-finished-a.example.com.target" ];
-      };
-
+    domainConfig = domain: {
       services.nginx.enable = true;
 
-      services.nginx.virtualHosts."a.example.com" = {
+      services.nginx.virtualHosts."${domain}" = {
         enableACME = true;
         forceSSL = true;
         locations."/".root = pkgs.runCommand "docroot" {} ''
           mkdir -p "$out"
-          echo hello world > "$out/index.html"
+          echo hello world from ${domain} > "$out/index.html"
         '';
       };
-
-      nesting.clone = [
-        ({pkgs, ...}: {
-
-          networking.extraHosts = ''
-            ${config.networking.primaryIPAddress} b.example.com
-          '';
-          systemd.targets."acme-finished-b.example.com" = {};
-          systemd.services."acme-b.example.com" = {
-            wants = [ "acme-finished-b.example.com.target" ];
-            before = [ "acme-finished-b.example.com.target" ];
-          };
-          services.nginx.virtualHosts."b.example.com" = {
-            enableACME = true;
-            forceSSL = true;
-            locations."/".root = pkgs.runCommand "docroot" {} ''
-              mkdir -p "$out"
-              echo hello world > "$out/index.html"
-            '';
-          };
-        })
-      ];
+    } // (fakeAcme domain);
+  in 
+  {
+    client = { nodes, pkgs, ... }: {
+      networking.extraHosts = nodes.webserver.config.networking.extraHosts; 
+      environment.systemPackages = [ pkgs.curl ];
     };
 
-    client = commonConfig;
+    webserver = { config, ... }: {
+      networking.firewall.allowedTCPPorts = [ 80 443 ];
+      networking.extraHosts = ''
+        ${config.networking.primaryIPAddress} ${domainA}
+        ${config.networking.primaryIPAddress} ${domainB}
+      '';
+      
+      nesting.clone = [ 
+        # child-1
+        (domainConfig domainA) 
+
+        # child-2
+        (lib.mkMerge [
+          (domainConfig domainA) 
+          (domainConfig domainB) 
+        ])
+      ];
+    };
   };
 
-  testScript = {nodes, ...}: 
-    let
-      newServerSystem = nodes.webserver2.config.system.build.toplevel;
-      switchToNewServer = "${newServerSystem}/bin/switch-to-configuration test";
-    in
+  testScript =
     # Note, waitForUnit does not work for oneshot services that do not have RemainAfterExit=true,
     # this is because a oneshot goes from inactive => activating => inactive, and never
     # reaches the active state. To work around this, we create some mock target units which
     # get pulled in by the oneshot units. The target units linger after activation, and hence we
     # can use them to probe that a oneshot fired. It is a bit ugly, but it is the best we can do
     ''
+      startAll;
       $client->waitForUnit("default.target");
-      $letsencrypt->waitForUnit("default.target");
-      $letsencrypt->waitForUnit("boulder.service");
 
-      subtest "can request certificate with HTTPS-01 challenge", sub {
-        $acmeStandalone->waitForUnit("default.target");
-        $acmeStandalone->succeed("systemctl start acme-standalone.com.service");
-        $acmeStandalone->waitForUnit("acme-finished-standalone.com.target");
+      subtest "add vhost a", sub {
+        $webserver->succeed("/run/booted-system/fine-tune/child-1/bin/switch-to-configuration test");
+        $webserver->waitForUnit("acme-finished-${domainA}.target");
+        $webserver->sleep(4);
+        $webserver->succeed("journalctl -b -u acme-${domainA} | grep -qF 'fetched cert for ${domainA}'");
+        $client->succeed('curl -k https://${domainA}/ | grep -qF "${domainA}"');
       };
 
-      subtest "Can request certificate for nginx service", sub {
-        $webserver->waitForUnit("acme-finished-a.example.com.target");
-        $client->succeed('curl https://a.example.com/ | grep -qF "hello world"');
+      subtest "add vhost b", sub {
+        $webserver->succeed("/run/booted-system/fine-tune/child-2/bin/switch-to-configuration test");
+        $webserver->waitForUnit("acme-finished-${domainB}.target");
+        $webserver->sleep(4);
+        $webserver->succeed("journalctl -b -u acme-${domainB} | grep -qF 'fetched cert for ${domainB}'");
+        $client->succeed('curl -k https://${domainB}/ | grep -qF "${domainB}"');
       };
 
-      subtest "Can add another certificate for nginx service", sub {
-        $webserver->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
-        $webserver->waitForUnit("acme-finished-b.example.com.target");
-        $client->succeed('curl https://b.example.com/ | grep -qF "hello world"');
+      subtest "back to a only", sub {
+        $webserver->succeed("/run/booted-system/fine-tune/child-1/bin/switch-to-configuration test");
+        $client->succeed('curl -k https://${domainA}/ | grep -qF "${domainA}"');
+        $client->mustFail('curl -k https://${domainB}/ | grep -qF "${domainB}"');
       };
     '';
-}
+})

--- a/nixos/tests/nesting.nix
+++ b/nixos/tests/nesting.nix
@@ -1,0 +1,42 @@
+import ./make-test.nix {
+  name = "nesting";
+  nodes =  {
+    clone = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.cowsay ];
+      nesting.clone = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [ pkgs.hello ];
+        })
+      ];
+    };
+    children = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.cowsay ];
+      nesting.children = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [ pkgs.hello ];
+        })
+      ];
+    };
+  };
+  testScript = ''
+    $clone->waitForUnit("default.target");
+    $clone->succeed("cowsay hey");
+    $clone->fail("hello");
+
+    # Nested clones do inherit from parent
+    $clone->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
+    $clone->succeed("cowsay hey");
+    $clone->succeed("hello");
+    
+
+    $children->waitForUnit("default.target");
+    $children->succeed("cowsay hey");
+    $children->fail("hello");
+
+    # Nested children do not inherit from parent
+    $children->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
+    $children->fail("cowsay hey");
+    $children->succeed("hello");
+
+  '';
+}

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "certbot";
-  version = "0.31.0";
+  version = "0.35.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rwjxmkpicyc9a5janvj1lfi430nq6ha94nyfgp11ds9fyydbh1s";
+    sha256 = "1z0acgmpp51zxkwi10cmbhhpc0fpgqmilxszf53zl9x1g23g4j8k";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "simp_le-client";
-  version = "0.9.0";
+  version = "0.15.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1yxfznd78zkg2f657v520zj5w4dvq5n594d0kpm4lra8xnpg4zcv";
+    sha256 = "0nkc7vsa08lxni3ss2i15dfdzr2m7ibhrwfh7gir85jfsglw38ph";
   };
 
   postPatch = ''


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] Nginx will be reloaded.

Changelog:

* Nginx: fix reload for multiple vhosts with automatic Letsencrypt certificates 
(#115661).
* Nginx: listen address (IPv4 and IPv6) can be configured in JSON vhost config now
(#115661).

## Security implications

* Fixing the reload failures has no new security implications.
* Nginx vhosts defined via JSON config still use the default of binding to all interfaces like before, but it can be limited now with the new option.

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)

