### PR TITLE
Remove unnecessary labels from redis metrics

### DIFF
--- a/nixos/modules/flyingcircus/roles/redis.nix
+++ b/nixos/modules/flyingcircus/roles/redis.nix
@@ -17,6 +17,12 @@ in
         cfg.redis.enable || cfg.redis4.enable;
 
       flyingcircus.roles.statshost.globalAllowedMetrics = [ "redis" ];
+
+      flyingcircus.roles.statshost.prometheusMetricRelabel = [
+        { regex = "aof_last_bgrewrite_status|aof_last_write_status|maxmemory_policy|rdb_last_bgsave_status|used_memory_dataset_perc|used_memory_peak_perc";
+          action = "labeldrop";
+        }
+      ];
     }
 
     (lib.mkIf cfg.redis4.enable {


### PR DESCRIPTION
bugs id: #119259

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Remove unecessary lables from Redis metrics (#119259)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

No special considerations necessary.

- [ ] Security requirements tested? (EVIDENCE)

