### PR TITLE
Always restart rabbitmq

### DIFF
--- a/nixos/modules/flyingcircus/services/rabbitmq.nix
+++ b/nixos/modules/flyingcircus/services/rabbitmq.nix
@@ -35,7 +35,10 @@ in {
   config = mkIf cfg.enable {
     systemd.services.rabbitmq = {
       environment.RABBITMQ_PLUGINS_DIR = plugins;
-      serviceConfig.LimitNOFILE = 65536;
+      serviceConfig = {
+        LimitNOFILE = 65536;
+        Restart = "always";
+      };
     };
     systemd.services.rabbitmq.path = [ pkgs.glibc ];
   };


### PR DESCRIPTION
* set Restart=always in unit file

Case 119477

@flyingcircusio/release-managers

## Release process

Impact:

* RabbitMQ will be restarted.

Changelog:

* Always restart RabbitMQ (#119477).

## Security implications

None.