### PR TITLE
update: grub -> 2.04

### DIFF
--- a/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
+++ b/nixos/modules/flyingcircus/infrastructure/fcio/default.nix
@@ -81,6 +81,7 @@ in
   # https://github.com/NixOS/nixpkgs/issues/12833
   boot.loader.grub.device = "/dev/disk/device-by-alias/root";
   boot.loader.grub.fsIdentifier = "provided";
+  boot.loader.grub.splashImage = null;
   boot.loader.grub.gfxmodeBios = "text";
   boot.loader.grub.timeout = 3;
   boot.loader.grub.version = 2;

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,61 +1,44 @@
-{ stdenv, fetchurl, fetchFromSavannah, autogen, flex, bison, python, autoconf, automake
-, gettext, ncurses, libusb, freetype, qemu, devicemapper
+{ stdenv, fetchgit, flex, bison, python, autoconf, automake, gnulib, libtool
+, gettext, ncurses, libusb, freetype, qemu, lvm2, unifont, pkgconfig
+, fuse # only needed for grub-mount
 , zfs ? null
-, efiSupport ? false
 , zfsSupport ? true
+, xenSupport ? false
 }:
 
 with stdenv.lib;
 let
-  pcSystems = {
-    "i686-linux".target = "i386";
-    "x86_64-linux".target = "i386";
-  };
-
-  efiSystems = {
-    "i686-linux".target = "i386";
-    "x86_64-linux".target = "x86_64";
-  };
-
-  canEfi = any (system: stdenv.system == system) (mapAttrsToList (name: _: name) efiSystems);
-  inPCSystems = any (system: stdenv.system == system) (mapAttrsToList (name: _: name) pcSystems);
-
-  version = "2.x-2015-07-27";
-
-  unifont_bdf = fetchurl {
-    url = "http://unifoundry.com/unifont-5.1.20080820.bdf.gz";
-    sha256 = "0s0qfff6n6282q28nwwblp5x295zd6n71kl43xj40vgvdqxv0fxx";
-  };
-
-  po_src = fetchurl {
-    name = "grub-2.02-beta2.tar.gz";
-    url = "http://alpha.gnu.org/gnu/grub/grub-2.02~beta2.tar.gz";
-    sha256 = "1lr9h3xcx0wwrnkxdnkfjwy08j7g7mdlmmbdip2db4zfgi69h0rm";
-  };
-
+  version = "2.04";
 in (
 
-assert efiSupport -> canEfi;
-assert zfsSupport -> zfs != null;
-
 stdenv.mkDerivation rec {
-  name = "grub-${version}";
+  pname = "grub";
+  inherit version;
+  name = "${pname}-${version}";
 
-  src = fetchFromSavannah {
-    repo = "grub";
-    rev = "72fc110d95129410443b898e931ff7a1db75312e";
-    sha256 = "0l2hws8h1jhww5s0m8pkwdggacpqb7fvz2jx83syg7ynczpgzbxs";
+  src = fetchgit {
+    url = "git://git.savannah.gnu.org/grub.git";
+    rev = "${pname}-${version}";
+    sha256 = "02gly3xw88pj4zzqjniv1fxa1ilknbq1mdk30bj6qy8n44g90i8w";
   };
 
-  nativeBuildInputs = [ autogen flex bison python autoconf automake ];
-  buildInputs = [ ncurses libusb freetype gettext devicemapper ]
-    ++ optional doCheck qemu
-    ++ optional zfsSupport zfs;
+  patches = [
+    ./fix-bash-completion.patch
+  ];
+
+  nativeBuildInputs = [ bison flex python pkgconfig autoconf automake ];
+  buildInputs = [ ncurses libusb freetype gettext lvm2 fuse libtool ]
+    ++ optional doCheck qemu;
+
+  hardeningDisable = [ "all" ];
+
+  # Work around a bug in the generated flex lexer (upstream flex bug?)
+  NIX_CFLAGS_COMPILE = "-Wno-error";
 
   preConfigure =
     '' for i in "tests/util/"*.in
        do
-         sed -i "$i" -e's|/bin/bash|/bin/sh|g'
+         sed -i "$i" -e's|/bin/bash|${stdenv.shell}|g'
        done
 
        # Apparently, the QEMU executable is no longer called
@@ -69,35 +52,30 @@ stdenv.mkDerivation rec {
        # See <http://www.mail-archive.com/qemu-devel@nongnu.org/msg22775.html>.
        sed -i "tests/util/grub-shell.in" \
            -e's/qemu-system-i386/qemu-system-x86_64 -nodefaults/g'
+
+      unset CPP # setting CPP intereferes with dependency calculation
+
+      cp -r ${gnulib} $PWD/gnulib
+      chmod u+w -R $PWD/gnulib
+
+      patchShebangs .
+
+      ./bootstrap --no-git --gnulib-srcdir=$PWD/gnulib
+
+      substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
     '';
 
-  prePatch =
-    '' tar zxf ${po_src} grub-2.02~beta2/po
-       rm -rf po
-       mv grub-2.02~beta2/po po
-       sh autogen.sh
-       gunzip < "${unifont_bdf}" > "unifont.bdf"
-       sed -i "configure" \
-           -e "s|/usr/src/unifont.bdf|$PWD/unifont.bdf|g"
-    '';
-
-  patches = [ ./fix-bash-completion.patch ];
-
-  configureFlags = optional zfsSupport "--enable-libzfs"
-    ++ optionals efiSupport [ "--with-platform=efi" "--target=${efiSystems.${stdenv.system}.target}" "--program-prefix=" ];
+  configureFlags = [ "--enable-grub-mount" ]; # dep of os-prober
 
   # save target that grub is compiled for
-  grubTarget = if efiSupport
-               then "${efiSystems.${stdenv.system}.target}-efi"
-               else if inPCSystems
-                    then "${pcSystems.${stdenv.system}.target}-pc"
-                    else "";
+  grubTarget = "i386-pc";
 
   doCheck = false;
   enableParallelBuilding = true;
 
   postInstall = ''
-    paxmark pms $out/sbin/grub-{probe,bios-setup}
+    # Avoid a runtime reference to gcc
+    sed -i $out/lib/grub/*/modinfo.sh -e "/grub_target_cppflags=/ s|'.*'|' '|"
   '';
 
   meta = with stdenv.lib; {
@@ -115,10 +93,10 @@ stdenv.mkDerivation rec {
          operating system (e.g., GNU).
       '';
 
-    homepage = http://www.gnu.org/software/grub/;
+    homepage = https://www.gnu.org/software/grub/;
 
     license = licenses.gpl3Plus;
 
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 })


### PR DESCRIPTION
Use newer grub that (finally and hopefully effectively) fixes XFS's "new" on disk format
compatibility. First tests have shown no regression and actual improvement where
boot time improved and superfluous "invalid xfs node" messages disappeared.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Update grub to 2.04 for improved support of the modern XFS on-disk format and thus reducing reboot times.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

No specific requirements, review of changelog did not indicate new/unexpected risks to me as it mostly consists of bugfixes and nothing new related to anything exploitable over the network.

- [X] Security requirements tested? (EVIDENCE)

Nothing to test.

