### PR TITLE
graylog: 2.4.6 -> 2.5.2, fix sigar path

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/graylog.py
+++ b/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/graylog.py
@@ -43,6 +43,7 @@ log = logging.getLogger('fc-graylog')
 def main(ctx, api, user, password):
     graylog = requests.Session()
     graylog.auth = (user, password)
+    graylog.headers = {'X-Requested-By': 'cli'}
     graylog.api = api
     ctx.obj = graylog
 

--- a/nixos/modules/flyingcircus/packages/graylog/default.nix
+++ b/nixos/modules/flyingcircus/packages/graylog/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.6";
+  version = "2.5.2";
   name = "graylog-${version}";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "07bm5zz6b58ig082l6rwvvryh7svkv8nxp0d6izjka5f7x6g9ypw";
+    sha256 = "0ip13y3fq674pm3bfkwaxsj5iysq12zi0v4450d9c737i78zscfb";
   };
 
   dontBuild = true;

--- a/nixos/modules/flyingcircus/services/graylog.nix
+++ b/nixos/modules/flyingcircus/services/graylog.nix
@@ -190,7 +190,7 @@ in
         JAVA_HOME = jre;
         GRAYLOG_CONF = "${confFile}";
         GRAYLOG_PID = pidFile;
-        JAVA_OPTS = "-Djava.library.path=\${GRAYLOGCTL_DIR}/../lib/sigar -Xms${cfg.javaHeap} -Xmx${cfg.javaHeap} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow";
+        JAVA_OPTS = "-Djava.library.path=${cfg.package}/lib/sigar -Xms${cfg.javaHeap} -Xmx${cfg.javaHeap} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow";
       };
       path = with pkgs; [ openjdk8 which procps which ];
       serviceConfig = {


### PR DESCRIPTION
* needed in preparation for 3.x upgrade
* API non-GET requests need the X-Requested-By header now

Bugs id: #122100

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 15.09] Restarts graylog.

Changelog:

* Update graylog to 2.5.2. Important: non-GET API requests need a `X-Requested-By` header now https://docs.graylog.org/en/3.0/pages/upgrade/graylog-2.5.html

## Security implications

Update also fixes some security-related issues.

- [x] [Security requirements]
  - same behaviour as before, should not open additional ports, for example
- [x] Security requirements tested? (EVIDENCE)
  - reviewed graylog changelog
  - checked netstat output on test VM and compared it with the previous version: no changes