### PR TITLE
Fix insecure grafana default admin password (#122385), update grafana…

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -53,6 +53,7 @@ in rec {
     chromium
     elasticsearch6
     gnupg
+    grafana
     imagemagick
     kibana
     mercurial
@@ -85,7 +86,6 @@ in rec {
     firefox
     ghostscript
     git
-    grafana
     graphicsmagick
     iptables
     jbig2dec


### PR DESCRIPTION
- Fix insecure grafana default admin passwod (#122385)
- Pull in security updates to grafana itself which has authentication issues.
- Reset all sessions to log out potentially bad users immediately.
