### PR TITLE
Fix telegraf metrics collection for graylog 2.5

### DIFF
--- a/nixos/modules/flyingcircus/roles/graylog.nix
+++ b/nixos/modules/flyingcircus/roles/graylog.nix
@@ -485,7 +485,7 @@ in
       '';
 
       services.telegraf.inputs.graylog = [{
-        servers = [ "${restListenUri}/system/metrics/multiple" ];
+        servers = [ "http://localhost:9003/api/system/metrics/multiple" ];
         metrics = [ "jvm.memory.total.committed"
                     "jvm.memory.total.used"
                     "jvm.threads.count"
@@ -559,6 +559,11 @@ in
         ${listenConfig glAPIHAPort}
             use_backend stats if { path_beg /admin/stats }
             default_backend graylog
+
+        listen graylog_metrics
+            bind localhost:9003
+            http-request add-header X-Requested-By Telegraf
+            server local_graylog ${listenOn}:${toString glAPIPort}
 
         backend gelf_tcp
             mode tcp


### PR DESCRIPTION
Graylog 2.5 expects the X-Requested-By header on POST requests which are
used by the telegraf graylog plugin to gather metrics. Our telegraf
version is too old and doesn't know that. Using haproxy to add the
missing header fixes it.

bugs id: #122408


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 15.09] Telegraf will be restarted.

Changelog:

* Fix telegraf metrics collection for graylog (#122408).

## Security implications

- opens a new port 9003 for graylog API access

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Port must not be reachable from the outside, only for local access 
- [x] Security requirements tested? (EVIDENCE)
  - manual check in dev: haproxy binds to localhost and port can't be reached from the outside