### PR TITLE
Update global virtualenv to version 16

### DIFF
--- a/nixos/modules/flyingcircus/packages/all-packages.nix
+++ b/nixos/modules/flyingcircus/packages/all-packages.nix
@@ -350,6 +350,8 @@ in rec {
   # have to callPackage them instead of using the pre-made package.
   virtualboxGuestAdditions = pkgs_18_03.callPackage "${pkgs_18_03_src}/pkgs/applications/virtualization/virtualbox/guest-additions" { kernel = linux_4_4; };
 
+  virtualenv_16 = pkgs_18_09.pythonPackages.virtualenv;
+
   xtrabackup = pkgs_18_09.callPackage ./percona/xtrabackup.nix {
     inherit percona;
     boost = pkgs_18_09.boost168;

--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -60,7 +60,7 @@
         pwgen
         python2Full
         python34
-        pythonPackages.virtualenv
+        virtualenv_16
         ripgrep
         screen
         strace


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Update globally available Python virtualenv package to version 16 (#124061).

## Security implications

n/a
