### PR TITLE
Don't collect fc_collect_garbage metric anymore

### DIFF
--- a/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
+++ b/nixos/modules/flyingcircus/platform/garbagecollect/default.nix
@@ -107,18 +107,6 @@ in {
         }
       '';
 
-      services.telegraf.inputs = {
-        logparser = [ {
-          files = [ "/var/log/fc-collect-garbage.log" ];
-          grok = {
-            patterns = [
-              "%{DATESTAMP_RFC2822:timestamp} time=%{DURATION:time:duration}"
-            ];
-            measurement = "fc_collect_garbage";
-          };
-        } ];
-      };
-
       systemd.timers.fc-collect-garbage = {
         description = "Timer for fc-collect-garbage";
         wantedBy = [ "timers.target" ];


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Remove fc_collect_garbage metric (#123906).

## Security implications

n/a

