### PR TITLE
126100 add py36 system wide

### DIFF
--- a/nixos/modules/flyingcircus/platform/packages.nix
+++ b/nixos/modules/flyingcircus/platform/packages.nix
@@ -60,6 +60,7 @@
         pwgen
         python2Full
         python34
+        python36
         virtualenv_16
         ripgrep
         screen


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

* Add Python 3.6 systemwide and by default. Not overriding Python 3.4 as the platform's default python3 executable, though. (#126100)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

No additional requirements. Python 3 (and 3.6) is an accepted package that is required for bootstrapping various applications like batou 2. For increased compatibility between our 19.03 and 15.09 platforms we provide this now system-wide by default. It was already possible to enable previously.

- [X] Security requirements tested? (EVIDENCE)

The default Python is not changed. Tested by applying on test environment.
