### PR TITLE
fc-manage service: add tar and compression tools to PATH

### DIFF
--- a/nixos/modules/flyingcircus/services/agent.nix
+++ b/nixos/modules/flyingcircus/services/agent.nix
@@ -95,9 +95,13 @@ in {
           KillMode = "none";
         };
         path = with pkgs; [
-          fcmanage
-          xfsprogs
+          bzip2
           config.system.build.nixos-rebuild
+          fcmanage
+          gnutar
+          gzip
+          xfsprogs
+          xz
         ];
 
         # This configuration is stolen from NixOS' own automatic updater.


### PR DESCRIPTION
This is needed if someone wants to use fetchTarball in the local NixOS
config, for example to fetch a newer channel.

Case 124799 (back-ported from 19.03 platform)

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

Add tar and compression tools to fc-manage. Using fetchTarball in local NixOS config doesn’t break automatic configuration anymore (#124799).

## Security implications

n/a

