### PR TITLE
Security fix for OpenSSL 1.1.1.

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -132,8 +132,8 @@ in {
   };
 
   openssl_1_1 = common {
-    version = "1.1.1d";
-    sha256 = "1whinyw402z3b9xlb3qaxv4b9sk4w1bgh9k0y8df1z4x3yy92fhy";
+    version = "1.1.1g";
+    sha256 = "0ikdcc038i7jk8h7asq5xcn8b1xc2rrbc88yfm4hqbz3y5s4gc6x";
     patches = [
       ./1.1/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
Closes #576
Case 126583

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Security update for OpenSSL 1.1.1

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

This is a vulnerability and we need to apply available fixes (security update process). The patch is within the 1.1.1 series and those are generally trustworthy from our perspective.

- [X] Security requirements tested? (EVIDENCE)

1.1.1g is the newest unaffected according to the CVE.