### PR TITLE
ACME: use HTTP for the Nginx readyness check

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -214,17 +214,17 @@ in
                     StateDirectory = lpath;
                     StateDirectoryMode = rights;
                     WorkingDirectory = "/var/lib/${lpath}";
-                    ExecStartPre = 
-                      let 
+                    ExecStartPre =
+                      let
                         script = pkgs.writeScript "acme-pre-start" ''
                           #!${pkgs.runtimeShell} -e
                           mkdir -p ${acmeChallengeDir}
                           chown ${data.user}:${data.group} ${acmeChallengeDir}
                           touch ${acmeChallengeDir}/${checkFile}
                           for x in 1 2 3 4 5; do
-                            echo "Checking if web server is serving the challenge dir..." 
-                            ${pkgs.curl}/bin/curl --insecure --output /dev/null --silent --head --fail \
-                              https://${cert}/.well-known/acme-challenge/${checkFile} &&
+                            echo "Checking if web server is serving the challenge dir..."
+                            ${pkgs.curl}/bin/curl --output /dev/null --silent --head --fail \
+                              http://${cert}/.well-known/acme-challenge/${checkFile} &&
                               rm ${acmeChallengeDir}/${checkFile} &&
                               exit 0
 
@@ -236,9 +236,9 @@ in
                         '';
                       in
                         "+${script}";
-                    
+
                     ExecStart = "${pkgs.simp_le}/bin/simp_le ${escapeShellArgs cmdline}";
-                    ExecStopPost = 
+                    ExecStopPost =
                       let
                         script = pkgs.writeScript "acme-post-stop" ''
                           #!${pkgs.runtimeShell} -e


### PR DESCRIPTION
This avoids conflicts with other services that want to use port 443.
Our current use case for this is a TURN server using 443.
Nginx can be configured to only listen on port 80 now.
The acme client uses HTTP for challenges.

Case 126629

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix port conflict on 443 when Letsencrypt is used. This makes it possible to run a TURN server on 443 with automated letsencrypt certs, for example. 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - only affects an internal check on a port that must be open anyways for letsencrypt
- [x] Security requirements tested? (EVIDENCE)
  - nothing to test