### PR TITLE
Retry nixos-rebuild switch if the first run fails

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/manage.py
+++ b/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/manage.py
@@ -29,7 +29,8 @@ ACTIVATE = """\
 set -e
 nix-channel --add {url} nixos
 nix-channel --update nixos
-nixos-rebuild switch
+# Retry once in case nixos-build fails e.g. due to updates to Nix itself
+nixos-rebuild switch || nixos-rebuild switch
 nix-channel --remove next
 """
 


### PR DESCRIPTION
Backport from 19.03 fc-nixos.
Avoids the expected error on 19.03 upgrades and other temporary failures.

Case 127000

See https://github.com/flyingcircusio/fc-nixos/pull/86

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

Just a retry to avoid uninteresting error messages that would be fixed by the next fc-manage run, resulting in the same system state.
