### PR TITLE
127887 disable autoconf

### DIFF
--- a/nixos/modules/flyingcircus/platform/network.nix
+++ b/nixos/modules/flyingcircus/platform/network.nix
@@ -206,9 +206,11 @@ in
               path = [ pkgs.nettools pkgs.procps ];
               script = ''
                 nameif eth${vlan} ${mac}
+                sysctl net.ipv6.conf.eth${vlan}.accept_ra=0
                 sysctl net.ipv6.conf.eth${vlan}.autoconf=0
               '';
               preStop = ''
+                sysctl net.ipv6.conf.eth${vlan}.accept_ra=1
                 sysctl net.ipv6.conf.eth${vlan}.autoconf=1
               '';
               serviceConfig = {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

None

Changelog:

* Disable dynamic router_advertisements for IPv6. This caused some frontend traffic to be flooded to unrelated VMs. Even though this looks dramatic, the affected traffic was public internet traffic so security policies require encryption anyway and we've seen encrypted traffic only, anyway. It did cause superfluous traffic in the network, though.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Customer traffic should not appear on non-target VMs. As this only affecte the frontend network, additional security policies already required that this should be encrypted and from our analysis we have only seen encrypted traffic flooded anyway.

- [X] Security requirements tested? (EVIDENCE)

Validated the new settings with our previous platform (which already used the setting but got lost at some point in the migration). Also checked on customer affected machine that this setting solves the problem and manually verified that the changed automation code is applied properly.

