### PR TITLE
Fix #126783: Vagrant was stuck on boot due to nginx config test

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -707,11 +707,15 @@ in
     };
 
     system.activationScripts.nginx-reload-check = lib.stringAfter [ "resolvconf" ] ''
-      nginx_check_msg=$(${checkConfigCmd} 2>&1) || rc=$?
-      if [[ -n $rc ]]; then
-        printf "\033[0;31mWarning: \033[0mNginx config is invalid at this point:\n$nginx_check_msg\n"
-        echo Reload may still work if missing Let\'s Encrypt SSL certs are the reason, for example.
-        echo Please check the output of journalctl -eu nginx
+      ${pkgs.procps}/bin/pgrep nginx > /dev/null || nginx_running=$?
+      if [[ ! -n $nginx_running ]]; then 
+        nginx_check_msg=$(${checkConfigCmd} 2>&1) || rc=$?
+
+        if [[ -n $rc ]]; then
+          printf "\033[0;31mWarning: \033[0mNginx config is invalid at this point:\n$nginx_check_msg\n"
+          echo Reload may still work if missing Let\'s Encrypt SSL certs are the reason, for example.
+          echo Please check the output of journalctl -eu nginx
+        fi
       fi
     '';
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -707,8 +707,7 @@ in
     };
 
     system.activationScripts.nginx-reload-check = lib.stringAfter [ "resolvconf" ] ''
-      ${pkgs.procps}/bin/pgrep nginx > /dev/null || nginx_running=$?
-      if [[ ! -n $nginx_running ]]; then 
+      if ${pkgs.procps}/bin/pgrep nginx &> /dev/null; then 
         nginx_check_msg=$(${checkConfigCmd} 2>&1) || rc=$?
 
         if [[ -n $rc ]]; then


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Do not verify nginx config within the activation scripts if no nginx is running. This slowed down Vagrant machines extremely as validating SSL configs requires cryptographically secure RNG and Linux takes a long time in Virtualbox/Vagrant during boot to reach that state. (#126783)

## Security implications

n/a