### PR TITLE
fc-agent, manage.py: fix Hydra SSL verification

### DIFF
--- a/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/manage.py
+++ b/nixos/modules/flyingcircus/packages/fcmanage/fc/manage/manage.py
@@ -41,6 +41,7 @@ class Channel:
 
     # global, to avoid re-connecting (with ssl handshake and all)
     session = requests.session()
+    session.verify = "/etc/ssl/certs/ca-bundle.crt"
     hydra_reachable = True
     is_local = False
 


### PR DESCRIPTION
The requests package uses a vendored SSL bundle by default that
doesn't have the required root cert used by our Hydra so channel updates
weren't possible anymore.
Use the newer system cert bundle instead for verification instead.

Nix itself uses the system bundle so it wasn't affected by the problem,
only the availability check in manage.py failed and prevented updates.

 #PL-130290

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* [hotfix] fc-manage: Fix channel updates that were broken by the Letsencrypt root certificate change last year.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix platform updates, properly verify SSL requests to Hydra
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that fc-manage is able to update the channel
  - the system cert bundle which is also used by other parts of the update mechanism is used by the requests package now 