### PR TITLE
[PL-132647] check-meta: fcio-specific errors for unfree/insecure packages

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -128,6 +128,12 @@ let
           conflicts = [ "shutdown.target" ];
           wantedBy = [ "multi-user.target" ] ++ optional hasDefaultGatewaySet "network-online.target";
 
+          # Stop+starting the network can break
+          # switch-to-configuration on NFS clients by reloading the
+          # systemd config when the NFS server is unreachable. Do an
+          # in-place restart after systemd has reloaded instead.
+          stopIfChanged = false;
+
           unitConfig.ConditionCapability = "CAP_NET_ADMIN";
 
           path = [ pkgs.iproute2 ];

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -89,30 +89,19 @@ let
 
         deviceDependency =
           dev:
-          # Use systemd service if we manage device creation, else
-          # trust udev when not in a container
-          if (dev == null || dev == "lo") then
+          if (dev == null || dev == "lo" || config.boot.isContainer) then
             [ ]
-          else if
-            (hasAttr dev (filterAttrs (k: v: v.virtual) cfg.interfaces))
-            || (hasAttr dev cfg.bridges)
-            || (hasAttr dev cfg.bonds)
-            || (hasAttr dev cfg.macvlans)
-            || (hasAttr dev cfg.sits)
-            || (hasAttr dev cfg.vlans)
-            || (hasAttr dev cfg.greTunnels)
-            || (hasAttr dev cfg.vswitches)
-          then
-            [ "${dev}-netdev.service" ]
           else
-            optional (!config.boot.isContainer) (subsystemDevice dev);
+            [ "${dev}-netdev.service" ];
 
         hasDefaultGatewaySet =
           (cfg.defaultGateway != null && cfg.defaultGateway.address != "")
           || (cfg.enableIPv6 && cfg.defaultGateway6 != null && cfg.defaultGateway6.address != "");
 
-        needNetworkSetup =
-          cfg.resolvconf.enable || cfg.defaultGateway != null || cfg.defaultGateway6 != null;
+        # XXX we explicitly rely on network-setup.service being
+        # unconditionally present for triggering dependencies on
+        # interface units.
+        needNetworkSetup = true;
 
         networkLocalCommands = lib.mkIf needNetworkSetup {
           after = [ "network-setup.service" ];
@@ -122,14 +111,18 @@ let
         networkSetup = lib.mkIf needNetworkSetup {
           description = "Networking Setup";
 
-          after = [ "network-pre.target" ];
+          after = [
+            "network-pre.target"
+            "systemd-udevd.service"
+            "systemd-sysctl.service"
+          ];
           before = [
             "network.target"
             "shutdown.target"
           ];
           wants = [ "network.target" ];
-          # exclude bridges from the partOf relationship to fix container networking bug #47210
-          partOf = map (i: "network-addresses-${i.name}.service") (
+          # exclude bridges from the requires relationship to fix container networking bug #47210
+          requiredBy = map (i: "network-addresses-${i.name}.service") (
             filter (i: !(hasAttr i.name cfg.bridges)) interfaces
           );
           conflicts = [ "shutdown.target" ];
@@ -214,10 +207,12 @@ let
             wantedBy = [
               "network-setup.service"
               "network.target"
+              "multi-user.target"
             ];
             # order before network-setup because the routes that are configured
             # there may need ip addresses configured
             before = [ "network-setup.service" ];
+            requires = [ "network-setup.service" ];
             bindsTo = deviceDependency i.name;
             after = [ "network-pre.target" ] ++ (deviceDependency i.name);
             serviceConfig.Type = "oneshot";
@@ -303,6 +298,7 @@ let
               "network-setup.service"
               (subsystemDevice i.name)
             ];
+            requires = [ "network-setup.service" ];
             before = [ "network-setup.service" ];
             path = [ pkgs.iproute2 ];
             serviceConfig = {
@@ -330,7 +326,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps ++ optional v.rstp "mstpd.service";
-              partOf = [ "network-setup.service" ] ++ optional v.rstp "mstpd.service";
+              requires = [ "network-setup.service" ] ++ optional v.rstp "mstpd.service";
               after =
                 [ "network-pre.target" ]
                 ++ deps
@@ -436,7 +432,7 @@ let
               # should work without internalConfigs dependencies because address/link configuration depends
               # on the device, which is created by ovs-vswitchd with type=internal, but it does not...
               before = [ "network-setup.service" ] ++ internalConfigs;
-              partOf = [ "network-setup.service" ]; # shutdown the bridge when network is shutdown
+              requires = [ "network-setup.service" ]; # shutdown the bridge when network is shutdown
               bindsTo = [ "ovs-vswitchd.service" ]; # requires ovs-vswitchd to be alive at all times
               after = [
                 "network-pre.target"
@@ -503,6 +499,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps ++ map (i: "network-addresses-${i}.service") v.interfaces;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -551,6 +548,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -594,6 +592,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -623,6 +622,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -665,6 +665,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -699,7 +700,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
-              partOf = [ "network-setup.service" ];
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -172,7 +172,7 @@ let
   pos_str = meta: meta.position or "«unknown-file»";
 
   remediation = {
-    unfree = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate");
+    unfree = remediate_unfree;
     non-source = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate");
     broken = remediate_allowlist "Broken" (x: "");
     unsupported = remediate_allowlist "UnsupportedSystem" (x: "");
@@ -230,6 +230,50 @@ let
     to ~/.config/nixpkgs/config.nix.
   '';
 
+  remediate_unfree = attrs: ''
+    You can install it anyway by allowing this package, using one of the
+    following methods:
+
+    a) if this happened while building a NixOS config, e.g. by
+       running `fc-manage switch`, you can add ‘${lib.getName attrs}’
+       to `flyingcircus.allowedUnfreePackageNames`, like this:
+
+         {
+           flyingcircus.allowedUnfreePackageNames = [
+             "${lib.getName attrs}"
+           ];
+         }
+
+    b) when using our channel tarballs (e.g. a tarball from the FCIO Hydra or
+       `import <fc> {}`), you can the following declarations to the `import` argument:
+
+         {
+           config.allowedUnfreePackageNames = [
+             "${lib.getName attrs}"
+           ];
+         }
+
+    c) when using nixpkgs directly (e.g. via `import <nixpkgs> {}`), you can add
+       the following declarations to the `import` argument:
+
+         {
+           # to allow ANY unfree package
+           config.allowUnfree = true;
+
+           # to allow ONLY THIS unfree package
+           config.allowUnfreePredicate = pkg: builtins.elem (pkg.pname or (builtins.parseDrvName pkg).name) [
+             "${lib.getName attrs}"
+           ];
+         }
+
+    d) temporarily allowing any unfree package can be enabled via
+
+         $ export NIXPKGS_ALLOW_UNFREE=1
+
+       Please note that this only advisable for interactive use, e.g. for `nix-shell`
+       and should NOT be used for NixOS configurations or user envs.
+  '';
+
   remediate_insecure =
     attrs:
     ''
@@ -239,34 +283,36 @@ let
     + (concatStrings (map (issue: " - ${issue}\n") attrs.meta.knownVulnerabilities))
     + ''
 
-      You can install it anyway by allowing this package, using the
+      You can install it anyway by allowing this package, using one of the
       following methods:
 
-      a) To temporarily allow all insecure packages, you can use an environment
-         variable for a single invocation of the nix tools:
+      a) if this happened while building a NixOS config, e.g. by
+         running `fc-manage switch`, you can add ‘${getNameWithVersion attrs}’
+         to `flyingcircus.permittedInsecurePackages`, like this:
+
+           {
+             flyingcircus.permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+      b) when using nixpkgs directly, you can set `permittedInsecurePackages` like this:
+
+           {
+             config.permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+         This is relevant when importing a channel tarball from Hydra
+         or the machine's nixpkgs (i.e. `import <nixpkgs>`), e.g. in a user env.
+
+      c) temporarily allowing any insecure package can be enabled via
 
            $ export NIXPKGS_ALLOW_INSECURE=1
-           ${flakeNote}
-      b) for `nixos-rebuild` you can add ‘${getNameWithVersion attrs}’ to
-         `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
-         like so:
 
-           {
-             nixpkgs.config.permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
-      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-         ‘${getNameWithVersion attrs}’ to `permittedInsecurePackages` in
-         ~/.config/nixpkgs/config.nix, like so:
-
-           {
-             permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
+         Please note that this only advisable for interactive use, e.g. for `nix-shell`
+         and should NOT be used for NixOS configurations or user envs.
     '';
 
   remediateOutputsToInstall =


### PR DESCRIPTION
PL-132647

cc @flyingcircusio/release-managers 
__Note:__ this depends on https://github.com/flyingcircusio/fc-nixos/pull/1571.

Other kinds of packages aren't impacted by the problem, but for two all suggestions aren't really helpful, i.e.

* the `nixpkgs.config` declarations are replaced by others from the platform code (and `nixpkgs.config`-merging is known to be broken).

* most of the time, a user-env doesn't use `<nixpkgs>`, but our channel tarball which silently discards unfree/insecure allow-lists in favor of platform-defined ones.

* using NIXPKGS_* env-vars often doesn't do what you want because you'd have to add it to `fc-agent.service` (and use `sudo -E` on interactive use) which is also not entirely obvious.

Yes, carrying a patch around that's non-upstreamable is nasty, but I do think it's WAY better than giving our ops team and customers non-actionable suggestions in an error message.

