### PR TITLE
mailman: do not require nginx uwsgiPass option

### DIFF
--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -515,7 +515,7 @@ in
       enable = lib.mkDefault true;
       virtualHosts = lib.genAttrs cfg.webHosts (webHost: {
         locations = {
-          ${cfg.serve.virtualRoot}.uwsgiPass = "unix:/run/mailman-web.socket";
+          ${cfg.serve.virtualRoot}.extraConfig = "uwsgi_pass unix:/run/mailman-web.socket;";
           "${lib.removeSuffix "/" cfg.serve.virtualRoot}/static/".alias = webSettings.STATIC_ROOT + "/";
         };
       });


### PR DESCRIPTION
Partial revert of d1a28bbdb48244f7a3edf027e4c90b6de0bb1bf3

Reason:
In fc-nixos, the services.nginx module is shadowed by a vendored nginx base-module.nix, so changes (and reverts) in this nixpkgs fork repository do not have any effect.
That vendored base-module is too old though to have the `uwsgiPass` option. `services.mailman` is the only module as of now relying on that option, so we revert it back to work with the older style nginx module.

This is a stop-gap solution only applied to the 25.05 nixpkgs branch, as we finally adapt the current `services.nginx` module in fc-nixos-25.11.

PL-133981

tested:
- dry-build on our mailman host, ensuring that the system configuration builds again