### PR TITLE
nixos/grub: re-install grub on package change

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -686,11 +686,13 @@ struct(GrubState => {
     devices => '$',
     efiMountPoint => '$',
     extraGrubInstallArgs => '@',
+    grub => '$',
+    grubEfi => '$',
 });
 # If you add something to the state file, only add it to the end
 # because it is read line-by-line.
 sub readGrubState {
-    my $defaultGrubState = GrubState->new(name => "", version => "", efi => "", devices => "", efiMountPoint => "", extraGrubInstallArgs => () );
+    my $defaultGrubState = GrubState->new(name => "", version => "", efi => "", devices => "", efiMountPoint => "", extraGrubInstallArgs => [], grub => "", grubEfi => "" );
     open my $fh, "<", "$bootPath/grub/state" or return $defaultGrubState;
     local $/ = "\n";
     my $name = <$fh>;
@@ -721,8 +723,10 @@ sub readGrubState {
     }
     my %jsonState = %{decode_json($jsonStateLine)};
     my @extraGrubInstallArgs = exists($jsonState{'extraGrubInstallArgs'}) ? @{$jsonState{'extraGrubInstallArgs'}} : ();
+    my $grubValue = exists($jsonState{'grub'}) ? $jsonState{'grub'} : "";
+    my $grubEfiValue = exists($jsonState{'grubEfi'}) ? $jsonState{'grubEfi'} : "";
     close $fh;
-    my $grubState = GrubState->new(name => $name, version => $version, efi => $efi, devices => $devices, efiMountPoint => $efiMountPoint, extraGrubInstallArgs => \@extraGrubInstallArgs );
+    my $grubState = GrubState->new(name => $name, version => $version, efi => $efi, devices => $devices, efiMountPoint => $efiMountPoint, extraGrubInstallArgs => \@extraGrubInstallArgs, grub => $grubValue, grubEfi => $grubEfiValue );
     return $grubState
 }
 
@@ -734,15 +738,16 @@ my @prevExtraGrubInstallArgs = @{$prevGrubState->extraGrubInstallArgs};
 
 my $devicesDiffer = scalar (List::Compare->new( '-u', '-a', \@deviceTargets, \@prevDeviceTargets)->get_symmetric_difference());
 my $extraGrubInstallArgsDiffer = scalar (List::Compare->new( '-u', '-a', \@extraGrubInstallArgs, \@prevExtraGrubInstallArgs)->get_symmetric_difference());
-my $nameDiffer = get("fullName") ne $prevGrubState->name;
-my $versionDiffer = get("fullVersion") ne $prevGrubState->version;
 my $efiDiffer = $efiTarget ne $prevGrubState->efi;
 my $efiMountPointDiffer = $efiSysMountPoint ne $prevGrubState->efiMountPoint;
+# re-installing grub once the package store path changes is necessary, because
+# introducing patches or adjusting builds does not always bump the version number
+my $grubStorePathsDiffer = ($grub ne $prevGrubState->grub) || ($grubEfi ne $prevGrubState->grubEfi);
 if (($ENV{'NIXOS_INSTALL_GRUB'} // "") eq "1") {
     warn "NIXOS_INSTALL_GRUB env var deprecated, use NIXOS_INSTALL_BOOTLOADER";
     $ENV{'NIXOS_INSTALL_BOOTLOADER'} = "1";
 }
-my $requireNewInstall = $devicesDiffer || $extraGrubInstallArgsDiffer || $nameDiffer || $versionDiffer || $efiDiffer || $efiMountPointDiffer || (($ENV{'NIXOS_INSTALL_BOOTLOADER'} // "") eq "1");
+my $requireNewInstall = $devicesDiffer || $extraGrubInstallArgsDiffer || $efiDiffer || $efiMountPointDiffer || $grubStorePathsDiffer || (($ENV{'NIXOS_INSTALL_BOOTLOADER'} // "") eq "1");
 
 # install a symlink so that grub can detect the boot drive
 my $tmpDir = File::Temp::tempdir(CLEANUP => 1) or die "Failed to create temporary space: $!";
@@ -795,7 +800,9 @@ if ($requireNewInstall != 0) {
     print $fh join( ",", @deviceTargets ), "\n" or die;
     print $fh $efiSysMountPoint, "\n" or die;
     my %jsonState = (
-        extraGrubInstallArgs => \@extraGrubInstallArgs
+        extraGrubInstallArgs => \@extraGrubInstallArgs,
+        grub => $grub,
+        grubEfi => $grubEfi
     );
     my $jsonStateLine = encode_json(\%jsonState);
     print $fh $jsonStateLine, "\n" or die;


### PR DESCRIPTION
Trigger re-installation of grub files when the store path of the grub package changes.
This is consistent with how side-effects are executed in other parts of NixOS, e.g. systemd service management, and ensures that the actually running grub stays in sync with the grub package in the Nix store that is part of the system closure.
In particular, this causes security patches or dependency changes to be taken into effect without the need to bump the package version.

Background:
So far we only re-installed grub outside of the store when its its version, the package name, or some flags changed.
This leads to the various security patches only fixing new installations of grub and not existing ones. This has been like this for over a decade, but it remains unclear why the implementation decision had been to be overly cautious with modifying boot loader side effects.

Tested:
- on a grub BIOS system in a qemu VM
- migration from an old grub state file works
- checked that grub is re-installed when the package store path changes
- checked that grub is not re-installed at system switch events with equal package store paths
- NOT tested on a grubEfi system

Fixes nixpkgs issue 486315

PL-135147


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
